### PR TITLE
Persistence ids

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -59,6 +59,11 @@ couchbase-journal {
     # will be occupied until this number of events has been fetched
     page-size = 100
 
+    # Smallest interval to re-query Couchbase to find new events or persistence ids when using the
+    # live variations of the queries. Lower values will make changes appear faster but will cause more
+    # load on the database.
+    live-query-interval = 1s
+
     events-by-tag {
       # For eventsByTag queries how long to delay the query for. For event writes that come from different nodes
       # the clocks may be out of sync meaning events aren't received in order. If the events are delivered to the

--- a/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournal.scala
@@ -10,7 +10,7 @@ import akka.NotUsed
 import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.event.Logging
-import akka.persistence.couchbase.internal.CouchbaseSchema.Fields
+import akka.persistence.couchbase.internal.CouchbaseSchema.{Fields, Queries}
 import akka.persistence.couchbase.internal._
 import akka.persistence.query._
 import akka.persistence.query.scaladsl._
@@ -43,8 +43,8 @@ object CouchbaseReadJournal {
     with EventsByTagQuery
     with CurrentEventsByTagQuery
     with CurrentPersistenceIdsQuery
-    // TODO actually implement:    with PersistenceIdsQuery
-    {
+    with PersistenceIdsQuery
+    with CouchbaseSchema.Queries {
 
   private implicit val system = eas
   private val log = Logging(system, configPath)
@@ -60,6 +60,7 @@ object CouchbaseReadJournal {
 
     CouchbaseReadJournalSettings(sharedConfig)
   }
+  def bucketName: String = settings.bucket
 
   protected val asyncSession: Future[CouchbaseSession] = CouchbaseSession(settings.sessionSettings, settings.bucket)
   asyncSession.failed.foreach { ex =>
@@ -69,40 +70,6 @@ object CouchbaseReadJournal {
   system.registerOnTermination {
     closeCouchbaseSession()
   }
-
-  /* Both these queries flattens the doc.messages (which can contain batched writes)
-   * into elements in the result and adds a field for the persistence id from
-   * the surrounding document. Note that the UNNEST name (m) must match the name used
-   * for the array value in the index or the index will not be used for these
-   */
-  private val eventsByTagQuery =
-    s"""
-      |SELECT a.persistence_id, m.* FROM ${settings.bucket} a UNNEST messages AS m
-      |WHERE a.type = "${CouchbaseSchema.JournalEntryType}"
-      |AND ARRAY_CONTAINS(m.tags, $$tag) = true
-      |AND m.ordering > $$fromOffset AND m.ordering <= $$toOffset
-      |ORDER BY m.ordering
-      |limit $$limit
-    """.stripMargin
-
-  private val eventsByPersistenceId =
-    s"""
-      |SELECT a.persistence_id, m.* from ${settings.bucket} a UNNEST messages AS m
-      |WHERE a.type = "${CouchbaseSchema.JournalEntryType}"
-      |AND a.persistence_id = $$pid
-      |AND m.sequence_nr  >= $$from
-      |AND m.sequence_nr <= $$to
-      |ORDER by m.sequence_nr
-      |LIMIT $$limit
-    """.stripMargin
-
-  // IS NOT NULL is needed to hit the index
-  private val pidsQuery =
-    s"""
-       |SELECT DISTINCT(persistence_id) FROM ${settings.bucket}
-       |WHERE type = "${CouchbaseSchema.JournalEntryType}"
-       |AND persistence_id IS NOT NULL
-     """.stripMargin
 
   override def eventsByPersistenceId(persistenceId: String,
                                      fromSequenceNr: Long,
@@ -119,25 +86,18 @@ object CouchbaseReadJournal {
                                             fromSequenceNr: Long,
                                             toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     sourceWithCouchbaseSession { session =>
-      def params(from: Long) =
-        JsonObject
-          .create()
-          .put("pid", persistenceId)
-          .put("from", from)
-          .put("to", toSequenceNr)
-          .put("limit", settings.pageSize)
-
       // TODO do the deleted to query first and start from higher of that and fromSequenceNr
       val source =
         Source
           .fromGraph(
             new N1qlQueryStage[Long](
               live,
-              settings.pageSize,
-              N1qlQuery.parameterized(eventsByPersistenceId, params(fromSequenceNr)),
+              settings,
+              eventsByPersistenceIdQuery(persistenceId, fromSequenceNr, toSequenceNr, settings.pageSize),
               session.underlying,
               fromSequenceNr, { from =>
-                if (from <= toSequenceNr) Some(N1qlQuery.parameterized(eventsByPersistenceId, params(from)))
+                if (from <= toSequenceNr)
+                  Some(eventsByPersistenceIdQuery(persistenceId, from, toSequenceNr, settings.pageSize))
                 else None
               },
               (_, row) => row.value().getLong(Fields.SequenceNr) + 1
@@ -189,15 +149,6 @@ object CouchbaseReadJournal {
         TimeBasedUUIDSerialization.toSortableString(uuid)
       }
 
-      def params(fromOffset: String, toOffset: String): JsonObject =
-        JsonObject
-          .create()
-          .put("tag", tag)
-          .put("ordering", fromOffset)
-          .put("limit", settings.pageSize)
-          .put("fromOffset", fromOffset)
-          .put("toOffset", toOffset)
-
       // note that the result is "unnested" into the message objects + the persistence id, so the normal
       // document structure does not apply here
       val taggedRows: Source[AsyncN1qlQueryRow, NotUsed] =
@@ -205,11 +156,12 @@ object CouchbaseReadJournal {
           .fromGraph(
             new N1qlQueryStage[String](
               live,
-              settings.pageSize,
-              N1qlQuery.parameterized(eventsByTagQuery, params(initialOrderingString, endOffset)),
+              settings,
+              eventsByTagQuery(tag, initialOrderingString, endOffset, settings.pageSize),
               session.underlying,
-              initialOrderingString,
-              ordering => Some(N1qlQuery.parameterized(eventsByTagQuery, params(ordering, endOffset))), { (_, row) =>
+              initialOrderingString, { ordering =>
+                Some(eventsByTagQuery(tag, ordering, endOffset, settings.pageSize))
+              }, { (_, row) =>
                 row.value().getString(Fields.Ordering)
               }
             )
@@ -236,12 +188,38 @@ object CouchbaseReadJournal {
    * select  distinct persistenceId from akka where persistenceId is not null
    */
   override def currentPersistenceIds(): Source[String, NotUsed] = sourceWithCouchbaseSession { session =>
-    // this type works on the current queries we'd need to create a stage
-    // to do the live queries
-    // this can fail as it relies on async updates to the index.
-    val queryParams = N1qlParams.build().consistency(ScanConsistency.REQUEST_PLUS) // FIXME drop this consistency
+    log.debug("currentPersistenceIds query")
     // FIXME respect page size for this query as well?
-    session.streamedQuery(N1qlQuery.simple(pidsQuery, queryParams)).map(_.getString(Fields.PersistenceId))
+    session.streamedQuery(persistenceIdsQuery()).map(_.getString(Fields.PersistenceId))
   }
 
+  override def persistenceIds(): Source[String, NotUsed] = sourceWithCouchbaseSession { session =>
+    log.debug("persistenceIds query")
+    Source
+      .fromGraph(
+        new N1qlQueryStage[NotUsed](
+          live = true,
+          settings,
+          persistenceIdsQuery(),
+          session.underlying,
+          NotUsed,
+          nextQuery = _ => Some(persistenceIdsQuery()),
+          (_, _) => NotUsed
+        )
+      )
+      .mapMaterializedValue(_ => NotUsed)
+      .statefulMapConcat[String] { () =>
+        var seenIds = Set.empty[String]
+
+        { (row) =>
+          val id = row.value().getString(Fields.PersistenceId)
+          if (seenIds.contains(id)) Nil
+          else {
+            seenIds += id
+            id :: Nil
+          }
+        }
+      }
+
+  }
 }

--- a/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournal.scala
@@ -189,7 +189,7 @@ object CouchbaseReadJournal {
    */
   override def currentPersistenceIds(): Source[String, NotUsed] = sourceWithCouchbaseSession { session =>
     log.debug("currentPersistenceIds query")
-    // FIXME respect page size for this query as well?
+    // FIXME paging & respect page size for this query as well? #108
     session.streamedQuery(persistenceIdsQuery()).map(_.getString(Fields.PersistenceId))
   }
 

--- a/core/src/main/scala/akka/persistence/couchbase/settings.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/settings.scala
@@ -64,6 +64,7 @@ object CouchbaseJournalSettings {
 private[couchbase] final case class CouchbaseReadJournalSettings(sessionSettings: CouchbaseSessionSettings,
                                                                  bucket: String,
                                                                  pageSize: Int,
+                                                                 liveQueryInterval: FiniteDuration,
                                                                  eventByTagSettings: EventByTagSettings)
 final case class EventByTagSettings(eventualConsistencyDelay: FiniteDuration)
 
@@ -78,14 +79,15 @@ private[couchbase] object CouchbaseReadJournalSettings {
     val bucket = config.getString("write.bucket")
     val sessionSettings = CouchbaseSessionSettings(clientConfig)
 
-    val pagesize = config.getInt("read.page-size")
+    val pageSize = config.getInt("read.page-size")
 
     val eventByTagConfig = config.getConfig("read.events-by-tag")
     val eventByTagSettings = EventByTagSettings(
       eventByTagConfig.getDuration("eventual-consistency-delay").toMillis.millis
     )
+    val liveQueryInterval = config.getDuration("read.live-query-interval").toMillis.millis
 
-    CouchbaseReadJournalSettings(sessionSettings, bucket, pagesize, eventByTagSettings)
+    CouchbaseReadJournalSettings(sessionSettings, bucket, pageSize, liveQueryInterval, eventByTagSettings)
   }
 }
 

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseReadJournalSpec.scala
@@ -68,6 +68,34 @@ class CouchbaseReadJournalSpec
     }
   }
 
+  "live persistenceIds" must {
+    "show new persistence ids" in {
+      val senderProbe = TestProbe()
+      implicit val sender = senderProbe.ref
+
+      val queryProbe: TestSubscriber.Probe[String] =
+        queries.persistenceIds().runWith(TestSink.probe)
+
+      queryProbe.request(10)
+
+      val pa3 = system.actorOf(TestActor.props("p3"))
+      pa3 ! "p3-evt-1"
+      senderProbe.expectMsg("p3-evt-1-done")
+
+      awaitAssert({
+        queryProbe.expectNext("p3")
+      }, 5.seconds)
+
+      val pa4 = system.actorOf(TestActor.props("p4"))
+      pa4 ! "p4-evt-1"
+      senderProbe.expectMsg("p4-evt-1-done")
+
+      // we shouldn't see p3 again
+      queryProbe.expectNext("p4")
+
+    }
+  }
+
   // FIXME make these test independent i.e. don't rely on writes of previous test
   "liveEventsByTag" must {
 

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseReadJournalSpec.scala
@@ -92,6 +92,8 @@ class CouchbaseReadJournalSpec
 
       // we shouldn't see p3 again
       queryProbe.expectNext("p4")
+      // also not after p4 (it could come out of order)
+      queryProbe.expectNoMessage(waitTime)
 
     }
   }


### PR DESCRIPTION
On top of the eventsByPersistenceId query PR so review that one first.

Fixes #90 

Live query works but have to think a bit about paging for the non-live one: offset based paging and random order of persistence ids means queries could potentially miss persistence ids.

