### PR TITLE
Depend directly on patched version of sbt-dependency-graph

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,6 +15,9 @@ addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "0.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.14")
+// patched version of sbt-dependency-graph
+// depend directly on the patched version see https://github.com/akka/alpakka/issues/1388
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff")
 
 // patched version of sbt-dependency-graph for sbt-paradox-dependencies
 resolvers += Resolver.bintrayIvyRepo("2m", "sbt-plugins")


### PR DESCRIPTION
Makes sbt happy if the user has it as a global plugin already.