### PR TITLE
Update Lagom to version 1.5.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ def common: Seq[Setting[_]] = Seq(
                           "https://gitter.im/akka/dev",
                           url("https://github.com/akka/akka-persistence-couchbase/graphs/contributors")),
   licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-  crossScalaVersions := Seq("2.12.7", "2.11.12"),
+  crossScalaVersions := Seq("2.12.8", "2.11.12"),
   scalaVersion := crossScalaVersions.value.last,
   crossVersion := CrossVersion.binary,
   scalafmtOnCompile := true,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val AkkaVersion = "2.5.19"
   val AlpakkaCouchbaseVersion = "1.0-M2"
-  val LagomVersion = "1.5.0-M3"
+  val LagomVersion = "1.5.0-RC1"
   object Compile {
     // used to easily convert rxjava into reactive streams and then into akka streams
     val rxJavaReactiveStreams = "io.reactivex" % "rxjava-reactive-streams" % "1.2.1" // Apache V2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import sbt._
 
 object Dependencies {
 
-  val AkkaVersion = "2.5.19"
+  val AkkaVersion = "2.5.21"
   val AlpakkaCouchbaseVersion = "1.0-M2"
   val LagomVersion = "1.5.0-RC1"
   object Compile {
@@ -33,7 +33,7 @@ object Dependencies {
     val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test
 
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % Test // EPL 1.0 / LGPL 2.1
-    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test // ApacheV2
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5" % Test // ApacheV2
     val junit = "junit" % "junit" % "4.12" % Test
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % Test
 
@@ -41,7 +41,7 @@ object Dependencies {
     val lagomTestKitJavaDsl = "com.lightbend.lagom" %% "lagom-javadsl-testkit" % LagomVersion % Test
     val lagomPersistenceTestKit = "com.lightbend.lagom" %% "lagom-persistence-testkit" % LagomVersion % Test
 
-    val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.25" % Test
+    val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.26" % Test
   }
 
   import Compile._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0") // for maintenance of copyright file header
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.1.0") // for maintenance of copyright file header
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0") // sources autoformat
 
 // whitesource for tracking licenses and vulnerabilities in dependencies


### PR DESCRIPTION
The primary purpose here is to update Lagom to version 1.5.0-RC1. But while I'm here, there are some more updates too.