### PR TITLE
Lagom 1.6.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ def common: Seq[Setting[_]] = Seq(
     "-Xlint",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Xfuture",
     "-Xfatal-warnings"
   ),
   bintrayOrganization := Some("akka"),
@@ -128,7 +127,6 @@ lazy val `copy-of-lagom-persistence-test` =
       // This modules copy-pasted preserve it as is
       scalafmtOnCompile := false,
       libraryDependencies := Dependencies.`copy-of-lagom-persistence-test`,
-      crossScalaVersions -= Dependencies.Scala213,
     )
 
 lazy val `lagom-persistence-couchbase-core` = (project in file("lagom-persistence-couchbase/core"))
@@ -139,7 +137,6 @@ lazy val `lagom-persistence-couchbase-core` = (project in file("lagom-persistenc
   .settings(
     name := "lagom-persistence-couchbase-core",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-core`,
-    crossScalaVersions -= Dependencies.Scala213,
   )
 
 lazy val `lagom-persistence-couchbase-javadsl` = (project in file("lagom-persistence-couchbase/javadsl"))
@@ -154,7 +151,6 @@ lazy val `lagom-persistence-couchbase-javadsl` = (project in file("lagom-persist
   .settings(
     name := "lagom-javadsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-javadsl`,
-    crossScalaVersions -= Dependencies.Scala213,
   )
   .enablePlugins(MultiJvmPlugin)
   .configs(MultiJvm)
@@ -172,7 +168,6 @@ lazy val `lagom-persistence-couchbase-scaladsl` = (project in file("lagom-persis
   .settings(
     name := "lagom-scaladsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-scaladsl`,
-    crossScalaVersions -= Dependencies.Scala213,
   )
   .enablePlugins(MultiJvmPlugin)
   .configs(MultiJvm)

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ inThisBuild(
 )
 
 def common: Seq[Setting[_]] = Seq(
-  crossScalaVersions := Seq(Dependencies.Scala213, Dependencies.Scala212, Dependencies.Scala211),
+  crossScalaVersions := Seq(Dependencies.Scala213, Dependencies.Scala212),
   scalaVersion := Dependencies.Scala212,
   crossVersion := CrossVersion.binary,
   scalafmtOnCompile := true,

--- a/core/src/main/scala/akka/persistence/couchbase/internal/CouchbaseSchema.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/CouchbaseSchema.scala
@@ -14,11 +14,11 @@ import akka.persistence.{PersistentRepr, SnapshotMetadata}
 import akka.serialization.{AsyncSerializer, Serialization, Serializers}
 import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
 import akka.util.OptionVal
+import akka.util.ccompat.JavaConverters._
 import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.{JsonArray, JsonObject}
 import com.couchbase.client.java.query.{N1qlParams, N1qlQuery}
 
-import scala.collection.JavaConverters._
 import scala.collection.{immutable => im}
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/akka/persistence/couchbase/internal/N1qlQueryStage.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/N1qlQueryStage.scala
@@ -109,7 +109,7 @@ private[akka] final class N1qlQueryStage[S](live: Boolean,
 
       override def preStart(): Unit = {
         if (live)
-          schedulePeriodicallyWithInitialDelay(Poll, settings.liveQueryInterval, settings.liveQueryInterval)
+          scheduleAtFixedRate(Poll, settings.liveQueryInterval, settings.liveQueryInterval)
         executeQuery(initialQuery)
       }
 

--- a/core/src/main/scala/akka/persistence/couchbase/scaladsl/CouchbaseReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/scaladsl/CouchbaseReadJournal.scala
@@ -27,6 +27,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.alpakka.couchbase.CouchbaseSessionRegistry
 import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
 import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ccompat.JavaConverters._
 import com.couchbase.client.java.document.json.JsonObject
 import com.couchbase.client.java.query._
 import com.typesafe.config.Config
@@ -344,7 +345,6 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
         .map {
           case (ordering, doc) =>
             val persistenceId = doc.content().getString(CouchbaseSchema.Fields.PersistenceId)
-            import scala.collection.JavaConverters._
             val messages = doc.content().getArray("messages").iterator().asScala
             val specificDoc = messages.find {
               case jo: JsonObject => jo.getString(CouchbaseSchema.Fields.Ordering) == ordering

--- a/core/src/test/scala/akka/testkit/WithLogCapturing.scala
+++ b/core/src/test/scala/akka/testkit/WithLogCapturing.scala
@@ -16,7 +16,7 @@ import org.scalatest.{Outcome, SuiteMixin, TestSuite}
 /**
  * Capture all log events and print them only for failing tests
  */
-trait WithLogCapturing extends SuiteMixin { this: TestSuite ⇒
+trait WithLogCapturing extends SuiteMixin { this: TestSuite =>
   implicit def system: ActorSystem
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
@@ -50,7 +50,7 @@ trait WithLogCapturing extends SuiteMixin { this: TestSuite ⇒
   }
 
   /** Adds a prefix to every line printed out during execution of the thunk. */
-  private def withPrefixedOut[T](prefix: String)(thunk: ⇒ T): T = {
+  private def withPrefixedOut[T](prefix: String)(thunk: => T): T = {
     val oldOut = Console.out
     val prefixingOut =
       new PrintStream(new OutputStream {
@@ -73,8 +73,8 @@ trait WithLogCapturing extends SuiteMixin { this: TestSuite ⇒
  */
 class DebugLogSilencingTestEventListener extends TestEventListener {
   override def print(event: Any): Unit = event match {
-    case d: Debug ⇒ // ignore
-    case _ ⇒ super.print(event)
+    case d: Debug => // ignore
+    case _ => super.print(event)
   }
 }
 

--- a/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideQuery.scala
+++ b/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideQuery.scala
@@ -12,7 +12,7 @@ import com.lightbend.lagom.scaladsl.persistence.couchbase.CouchbaseReadSide
 import docs.home.persistence.CouchbaseReadSideProcessorTwo.HelloEventProcessor
 import play.api.libs.json.{Format, Json}
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 // #imports
 

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/java/com/lightbend/lagom/javadsl/persistence/TestEntity.java
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/java/com/lightbend/lagom/javadsl/persistence/TestEntity.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.lightbend.lagom.javadsl.persistence.PersistentEntity.ReplyType;
+
 public class TestEntity extends PersistentEntity<TestEntity.Cmd, TestEntity.Evt, TestEntity.State> {
 
     public interface Cmd extends Jsonable {

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -4,7 +4,7 @@
 
 package com.lightbend.lagom.javadsl.persistence
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import java.util.Optional
 

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -106,7 +106,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
     roles.foreach(n => join(n, node1))
     within(15.seconds) {
       awaitAssert(Cluster(system).state.members.size should be(3))
-      awaitAssert(Cluster(system).state.members.toSeq.map(_.status) should be(Seq(MemberStatus.Up)))
+      awaitAssert(Cluster(system).state.members.toList.distinct.map(_.status) should be(List(MemberStatus.Up)))
     }
 
     enterBarrier("startup")

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -7,10 +7,11 @@ package com.lightbend.lagom.javadsl.persistence.multinode
 import java.util.concurrent.CompletionStage
 
 import akka.actor.{ ActorRef, ActorSystem, Address }
-import akka.cluster.{ Cluster, MemberStatus }
+import akka.cluster.{Cluster, MemberStatus}
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.testkit.ImplicitSender
+import akka.util.ccompat.JavaConverters._
 import com.lightbend.lagom.javadsl.persistence._
 import com.lightbend.lagom.javadsl.persistence.testkit.pipe
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -18,7 +19,6 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.{ Application, Configuration, Environment }
 
-import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -106,7 +106,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
     roles.foreach(n => join(n, node1))
     within(15.seconds) {
       awaitAssert(Cluster(system).state.members.size should be(3))
-      awaitAssert(Cluster(system).state.members.map(_.status) should be(Set(MemberStatus.Up)))
+      awaitAssert(Cluster(system).state.members.toSeq.map(_.status) should be(Seq(MemberStatus.Up)))
     }
 
     enterBarrier("startup")

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -17,8 +17,8 @@ object ActorSystemSpec {
     val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
       .dropWhile(_ matches "(java.lang.Thread|.*ActorSystemSpec.?$)")
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 ⇒ s
-      case z ⇒ s drop (z + 1)
+      case -1 => s
+      case z => s drop (z + 1)
     }
     reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
   }

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/persistence/PersistenceSpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/persistence/PersistenceSpec.scala
@@ -9,8 +9,8 @@ object PersistenceSpec {
     val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
       .dropWhile(_ matches "(java.lang.Thread|.*PersistenceSpec.?$)")
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 ⇒ s
-      case z ⇒ s drop (z + 1)
+      case -1 => s
+      case z => s drop (z + 1)
     }
     reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
   }

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -127,7 +127,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
     roles.foreach(n => join(n, node1))
     within(15.seconds) {
       awaitAssert(Cluster(system).state.members.size should be(3))
-      awaitAssert(Cluster(system).state.members.toSeq.map(_.status) should be(Seq(MemberStatus.Up)))
+      awaitAssert(Cluster(system).state.members.toList.distinct.map(_.status) should be(List(MemberStatus.Up)))
     }
 
     enterBarrier("startup")

--- a/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/copy-of-lagom-persistence-test/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.persistence.multinode
 
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.{ ActorRef, ActorSystem, Address, BootstrapSetup }
-import akka.cluster.{ Cluster, MemberStatus }
+import akka.cluster.{Cluster, MemberStatus}
 import akka.pattern.pipe
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
@@ -127,7 +127,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
     roles.foreach(n => join(n, node1))
     within(15.seconds) {
       awaitAssert(Cluster(system).state.members.size should be(3))
-      awaitAssert(Cluster(system).state.members.map(_.status) should be(Set(MemberStatus.Up)))
+      awaitAssert(Cluster(system).state.members.toSeq.map(_.status) should be(Seq(MemberStatus.Up)))
     }
 
     enterBarrier("startup")

--- a/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/TestConfig.scala
+++ b/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/TestConfig.scala
@@ -5,7 +5,7 @@
 package com.lightbend.lagom.internal.persistence.couchbase
 
 import com.typesafe.config.{Config, ConfigFactory}
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 object TestConfig {
 

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceModule.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceModule.scala
@@ -87,9 +87,7 @@ private[lagom] object CouchbasePersistenceModule {
         ServiceLocatorHolder(system).setServiceLocator(new ServiceLocatorAdapter {
           override def locateAll(name: String): Future[List[URI]] = {
             import system.dispatcher
-
-            import scala.collection.JavaConverters._
-            import scala.compat.java8.FutureConverters._
+            import akka.util.ccompat.JavaConverters._
             locator.locateAll(name).toScala.map(_.asScala.toList)
           }
         })

--- a/lagom-persistence-couchbase/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/lagom-persistence-couchbase/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import play.Application;
 import play.inject.Injector;
 import play.inject.guice.GuiceApplicationBuilder;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,9 +30,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.time.Duration;
 
 import static com.lightbend.lagom.internal.persistence.testkit.AwaitPersistenceInit.awaitPersistenceInit;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
@@ -125,7 +124,7 @@ public class PersistentEntityRefTest {
   @Test(expected = AskTimeoutException.class)
   public void testAskTimeout() throws Throwable {
     PersistentEntityRef<Cmd> ref = registry().refFor(TestEntity.class, "10").withAskTimeout(
-        FiniteDuration.create(1, MILLISECONDS));
+        Duration.ofMillis(1));
 
     List<CompletionStage<Evt>> replies = new ArrayList<>();
     for (int i = 0; i < 100; i++) {

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSideSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSideSpec.scala
@@ -16,7 +16,6 @@ import com.lightbend.lagom.scaladsl.persistence._
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 object CouchbaseReadSideSpec {
 
@@ -40,9 +39,7 @@ class CouchbaseReadSideSpec
 
   override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
 
-  override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
+  override def afterAll(): Unit =
     super.afterAll()
-  }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,10 @@ import sbt._
 object Dependencies {
   val Scala211 = "2.11.12"
   val Scala212 = "2.12.8"
-  val Scala213 = "2.13.0-M5"
+  val Scala213 = "2.13.0"
 
-  val AlpakkaCouchbaseVersion = "1.0.1"
   val AkkaVersion = "2.6.0-M4"
+  val AlpakkaCouchbaseVersion = "1.1.0"
   val LagomVersion = "1.6.0-M4"
   object Compile {
     // used to easily convert rxjava into reactive streams and then into akka streams
@@ -37,7 +37,7 @@ object Dependencies {
     val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test
 
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % Test // EPL 1.0 / LGPL 2.1
-    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5" % Test // ApacheV2
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % Test // ApacheV2
     val junit = "junit" % "junit" % "4.12" % Test
     val junitInterface = "com.novocode" % "junit-interface" % "0.11" % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,6 @@
 import sbt._
 
 object Dependencies {
-  val Scala211 = "2.11.12"
   val Scala212 = "2.12.8"
   val Scala213 = "2.13.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,9 +9,9 @@ object Dependencies {
   val Scala212 = "2.12.8"
   val Scala213 = "2.13.0-M5"
 
-  val AkkaVersion = "2.5.21"
   val AlpakkaCouchbaseVersion = "1.0.1"
-  val LagomVersion = "1.5.1"
+  val AkkaVersion = "2.6.0-M4"
+  val LagomVersion = "1.6.0-M4"
   object Compile {
     // used to easily convert rxjava into reactive streams and then into akka streams
     val rxJavaReactiveStreams = "io.reactivex" % "rxjava-reactive-streams" % "1.2.1" // Apache V2


### PR DESCRIPTION
## Purpose

Fixes #204.

Update to use Lagom 1.6.0-M4. This version is cross built to Scala 2.13, so this PR also updates from 2.13.0-M5 to 2.13.0 GA, which then requires some other deps updates.

Since `scalacOptions` is configured to fail on warnings, some code changes were made.

## Changes

- Lagom 1.6.0-M4
- Scala 2.13
- Akka 2.6.0-M4 (meaning Scala 2.11 is gone).

## Missing tasks

- [ ] Travis job to build using Scala 2.13.0