### PR TITLE
Version bumps and code style

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,3 +7,5 @@ indentOperator             = spray
 maxColumn                  = 120
 rewrite.rules              = [RedundantBraces, RedundantParens, SortImports]
 unindentTopLevelOperators  = true
+
+version = 2.2.2

--- a/build.sbt
+++ b/build.sbt
@@ -7,16 +7,20 @@ inThisBuild(
     organizationName := "Lightbend Inc.",
     homepage := Some(url("https://doc.akka.io/docs/akka-persistence-couchbase/current")),
     scmInfo := Some(
-      ScmInfo(url("https://github.com/akka/akka-persistence-couchbase"),
-              "https://github.com/akka/akka-persistence-couchbase.git")
-    ),
+        ScmInfo(
+          url("https://github.com/akka/akka-persistence-couchbase"),
+          "https://github.com/akka/akka-persistence-couchbase.git"
+        )
+      ),
     startYear := Some(2018),
-    developers += Developer("contributors",
-                            "Contributors",
-                            "https://gitter.im/akka/dev",
-                            url("https://github.com/akka/akka-persistence-couchbase/graphs/contributors")),
+    developers += Developer(
+        "contributors",
+        "Contributors",
+        "https://gitter.im/akka/dev",
+        url("https://github.com/akka/akka-persistence-couchbase/graphs/contributors")
+      ),
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-    description := "A replicated Akka Persistence journal backed by Couchbase",
+    description := "A replicated Akka Persistence journal backed by Couchbase"
   )
 )
 
@@ -26,37 +30,37 @@ def common: Seq[Setting[_]] = Seq(
   crossVersion := CrossVersion.binary,
   scalafmtOnCompile := true,
   scalacOptions ++= Seq(
-    "-encoding",
-    "UTF-8", // yes, this is 2 args
-    "-feature",
-    "-unchecked",
-    "-deprecation",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Xfuture",
-    "-Xfatal-warnings"
-  ),
+      "-encoding",
+      "UTF-8", // yes, this is 2 args
+      "-feature",
+      "-unchecked",
+      "-deprecation",
+      "-Xlint",
+      "-Ywarn-dead-code",
+      "-Ywarn-numeric-widen",
+      "-Xfuture",
+      "-Xfatal-warnings"
+    ),
   bintrayOrganization := Some("akka"),
   bintrayPackage := "akka-persistence-couchbase",
   bintrayRepository := (if (isSnapshot.value) "snapshots" else "maven"),
   // Setting javac options in common allows IntelliJ IDEA to import them automatically
   javacOptions in compile ++= Seq(
-    "-encoding",
-    "UTF-8",
-    "-source",
-    "1.8",
-    "-target",
-    "1.8",
-    "-parameters", // This param is required for Jackson serialization to preserve method parameter names
-    "-Xlint:unchecked",
-    "-Xlint:deprecation"
-  ),
+      "-encoding",
+      "UTF-8",
+      "-source",
+      "1.8",
+      "-target",
+      "1.8",
+      "-parameters", // This param is required for Jackson serialization to preserve method parameter names
+      "-Xlint:unchecked",
+      "-Xlint:deprecation"
+    ),
   headerLicense := Some(
-    HeaderLicense.Custom(
-      """Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>"""
-    )
-  ),
+      HeaderLicense.Custom(
+        """Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>"""
+      )
+    ),
   logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
   // show full stack traces and test case durations
   testOptions in Test += Tests.Argument("-oDF"),
@@ -80,8 +84,8 @@ def multiJvmTestSettings: Seq[Setting[_]] =
     // `database.port` required for multi-dc tests that extend AbstractClusteredPersistentEntityConfig
     MultiJvmKeys.jvmOptions in MultiJvm := Seq("-Ddatabase.port=0")
   ) ++
-    inConfig(MultiJvm)(ScalafmtPlugin.scalafmtConfigSettings) ++
-    headerSettings(MultiJvm)
+  inConfig(MultiJvm)(ScalafmtPlugin.scalafmtConfigSettings) ++
+  headerSettings(MultiJvm)
 
 lazy val root = (project in file("."))
   .settings(common)
@@ -90,7 +94,7 @@ lazy val root = (project in file("."))
     name := "akka-persistence-couchbase-root",
     publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))),
     // workaround for https://github.com/sbt/sbt/issues/3465
-    crossScalaVersions := List(),
+    crossScalaVersions := List()
   )
   .aggregate((Seq(core, docs) ++ lagomModules).map(Project.projectToRef): _*)
 
@@ -131,7 +135,7 @@ lazy val `copy-of-lagom-persistence-test` =
       // This modules copy-pasted preserve it as is
       scalafmtOnCompile := false,
       libraryDependencies := Dependencies.`copy-of-lagom-persistence-test`,
-      crossScalaVersions -= Dependencies.Scala213,
+      crossScalaVersions -= Dependencies.Scala213
     )
 
 lazy val `lagom-persistence-couchbase-core` = (project in file("lagom-persistence-couchbase/core"))
@@ -142,7 +146,7 @@ lazy val `lagom-persistence-couchbase-core` = (project in file("lagom-persistenc
   .settings(
     name := "lagom-persistence-couchbase-core",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-core`,
-    crossScalaVersions -= Dependencies.Scala213,
+    crossScalaVersions -= Dependencies.Scala213
   )
 
 lazy val `lagom-persistence-couchbase-javadsl` = (project in file("lagom-persistence-couchbase/javadsl"))
@@ -157,7 +161,7 @@ lazy val `lagom-persistence-couchbase-javadsl` = (project in file("lagom-persist
   .settings(
     name := "lagom-javadsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-javadsl`,
-    crossScalaVersions -= Dependencies.Scala213,
+    crossScalaVersions -= Dependencies.Scala213
   )
   .enablePlugins(MultiJvmPlugin)
   .configs(MultiJvm)
@@ -175,7 +179,7 @@ lazy val `lagom-persistence-couchbase-scaladsl` = (project in file("lagom-persis
   .settings(
     name := "lagom-scaladsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-scaladsl`,
-    crossScalaVersions -= Dependencies.Scala213,
+    crossScalaVersions -= Dependencies.Scala213
   )
   .enablePlugins(MultiJvmPlugin)
   .configs(MultiJvm)
@@ -193,14 +197,14 @@ lazy val docs = project
     Paradox / siteSubdirName := s"docs/akka-persistence-couchbase/${projectInfoVersion.value}",
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     paradoxProperties ++= Map(
-      "akka.version" -> Dependencies.AkkaVersion,
-      "alpakkaCouchbase.version" -> Dependencies.AlpakkaCouchbaseVersion,
-      "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
-      "extref.java-docs.base_url" -> "https://docs.oracle.com/en/java/javase/11/%s",
-      "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
-      "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
-      "scaladoc.com.typesafe.config.base_url" -> s"https://lightbend.github.io/config/latest/api/"
-    ),
+        "akka.version" -> Dependencies.AkkaVersion,
+        "alpakkaCouchbase.version" -> Dependencies.AlpakkaCouchbaseVersion,
+        "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
+        "extref.java-docs.base_url" -> "https://docs.oracle.com/en/java/javase/11/%s",
+        "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/current/",
+        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
+        "scaladoc.com.typesafe.config.base_url" -> s"https://lightbend.github.io/config/latest/api/"
+      ),
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io"

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ def common: Seq[Setting[_]] = Seq(
   ),
   headerLicense := Some(
     HeaderLicense.Custom(
-      """Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>"""
+      """Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>"""
     )
   ),
   logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
@@ -79,7 +79,9 @@ def multiJvmTestSettings: Seq[Setting[_]] =
   SbtMultiJvm.multiJvmSettings ++ Seq(
     // `database.port` required for multi-dc tests that extend AbstractClusteredPersistentEntityConfig
     MultiJvmKeys.jvmOptions in MultiJvm := Seq("-Ddatabase.port=0")
-  )
+  ) ++
+    inConfig(MultiJvm)(ScalafmtPlugin.scalafmtConfigSettings) ++
+    headerSettings(MultiJvm)
 
 lazy val root = (project in file("."))
   .settings(common)
@@ -93,7 +95,7 @@ lazy val root = (project in file("."))
   .aggregate((Seq(core, docs) ++ lagomModules).map(Project.projectToRef): _*)
 
 lazy val core = (project in file("core"))
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(HeaderPlugin)
   .settings(AutomaticModuleName.settings("akka.persistence.couchbase"))
   .settings(common)
   .settings(
@@ -136,7 +138,7 @@ lazy val `lagom-persistence-couchbase-core` = (project in file("lagom-persistenc
   .dependsOn(core % "compile;test->test")
   .settings(common)
   .settings(AutomaticModuleName.settings("lagom.persistence.couchbase.core"))
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(HeaderPlugin)
   .settings(
     name := "lagom-persistence-couchbase-core",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-core`,
@@ -151,7 +153,7 @@ lazy val `lagom-persistence-couchbase-javadsl` = (project in file("lagom-persist
     `lagom-persistence-couchbase-core` % "compile;test->test",
     `copy-of-lagom-persistence-test` % "test->test"
   )
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(HeaderPlugin)
   .settings(
     name := "lagom-javadsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-javadsl`,
@@ -169,7 +171,7 @@ lazy val `lagom-persistence-couchbase-scaladsl` = (project in file("lagom-persis
   )
   .settings(common)
   .settings(AutomaticModuleName.settings("lagom.persistence.couchbase.scaladsl"))
-  .enablePlugins(AutomateHeaderPlugin)
+  .enablePlugins(HeaderPlugin)
   .settings(
     name := "lagom-scaladsl-persistence-couchbase",
     libraryDependencies := Dependencies.`lagom-persistence-couchbase-scaladsl`,

--- a/core/src/main/scala/akka/persistence/couchbase/CouchbaseJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/CouchbaseJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -33,13 +33,11 @@ import scala.util.{Failure, Success, Try}
  */
 @InternalApi
 private[akka] object CouchbaseJournal {
-
   final case class PersistentActorTerminated(persistenceId: String)
 
   private final case class WriteFinished(persistenceId: String, f: Future[Done])
 
   private val ExtraSuccessFulUnit: Try[Unit] = Success(())
-
 }
 
 /**
@@ -51,7 +49,6 @@ class CouchbaseJournal(config: Config, configPath: String)
     with AsyncCouchbaseSession
     with Queries
     with TagSequenceNumbering {
-
   import CouchbaseJournal._
   import akka.persistence.couchbase.internal.CouchbaseSchema.Fields
 
@@ -164,8 +161,12 @@ class CouchbaseJournal(config: Config, configPath: String)
             for {
               serialized <- serializedF
               tagsAndSeqNrs <- tagsAndSeqNrsF
-            } yield
-              new TaggedMessageForWrite(persistentRepr.sequenceNr, serialized, uuidGenerator.nextUuid(), tagsAndSeqNrs)
+            } yield new TaggedMessageForWrite(
+              persistentRepr.sequenceNr,
+              serialized,
+              uuidGenerator.nextUuid(),
+              tagsAndSeqNrs
+            )
 
           case other =>
             SerializedMessage
@@ -292,7 +293,7 @@ class CouchbaseJournal(config: Config, configPath: String)
                 )
             }
           }
-      }
+        }
     )
   }
 }

--- a/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournalProvider.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/CouchbaseReadJournalProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -10,7 +10,6 @@ import com.typesafe.config.Config
 
 final class CouchbaseReadJournalProvider(as: ExtendedActorSystem, config: Config, configPath: String)
     extends ReadJournalProvider {
-
   override val scaladslReadJournal: scaladsl.CouchbaseReadJournal =
     new scaladsl.CouchbaseReadJournal(as, config, configPath)
 

--- a/core/src/main/scala/akka/persistence/couchbase/CouchbaseSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/CouchbaseSnapshotStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -29,7 +29,6 @@ import com.typesafe.config.Config
 import scala.concurrent.{ExecutionContext, Future}
 
 final class CouchbaseSnapshotStore(cfg: Config, configPath: String) extends SnapshotStore with AsyncCouchbaseSession {
-
   private val settings: CouchbaseSnapshotSettings = {
     // shared config is one level above the journal specific
     val commonPath = configPath.replaceAll("""\.snapshot""", "")
@@ -156,5 +155,4 @@ final class CouchbaseSnapshotStore(cfg: Config, configPath: String) extends Snap
 
     filter
   }
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/JsonSerializer.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/JsonSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -13,7 +13,6 @@ import com.couchbase.client.java.transcoder.JacksonTransformers
  * Subclass, implement and register through the regular Akka serialization infrastructure to use.
  */
 abstract class JsonSerializer extends SerializerWithStringManifest {
-
   def toJson(o: AnyRef): JsonObject
   def fromJson(json: JsonObject, manifest: String): AnyRef
 

--- a/core/src/main/scala/akka/persistence/couchbase/OutOfOrderEventException.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/OutOfOrderEventException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase

--- a/core/src/main/scala/akka/persistence/couchbase/UUIDs.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/UUIDs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -7,7 +7,6 @@ import akka.persistence.couchbase.internal.{TimeBasedUUIDs, UUIDTimestamp}
 import akka.persistence.query.{NoOffset, Offset, TimeBasedUUID}
 
 object UUIDs {
-
   /**
    * Create a time based UUID that can be used as offset in `eventsByTag`
    * queries. The `timestamp` is a unix timestamp (as returned by
@@ -30,5 +29,4 @@ object UUIDs {
    */
   def timestampFrom(offset: TimeBasedUUID): Long =
     new UUIDTimestamp(offset.value.timestamp()).toUnixTimestamp
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/AsyncCouchbaseSession.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/AsyncCouchbaseSession.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -19,7 +19,6 @@ import scala.util.Success
  */
 @InternalApi
 private[akka] trait AsyncCouchbaseSession {
-
   /**
    * Note: Implement with a val so that it doesn't get recreated on each access
    */
@@ -47,5 +46,4 @@ private[akka] trait AsyncCouchbaseSession {
       case Some(Success(session)) => session.close()
       case _ => asyncSession.flatMap(_.close())
     }
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/FutureUtils.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/FutureUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -13,7 +13,6 @@ import scala.concurrent.{ExecutionContext, Future}
  */
 @InternalApi
 private[akka] object FutureUtils {
-
   /**
    * Like Future.traverse but invokes `toFuture` on one A at a time, and does not execute the next one until
    * the returned `Future[B]` completes. Simplification of utilities in:
@@ -33,5 +32,4 @@ private[akka] object FutureUtils {
   )(zero: B)(toNextFuture: (B, A) => Future[B])(implicit ec: ExecutionContext): Future[B] =
     if (as.isEmpty) Future.successful(zero)
     else toNextFuture(zero, as.head).flatMap(b => foldLeftSequential(as.tail)(b)(toNextFuture))
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/N1qlQueryStage.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/N1qlQueryStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -34,22 +34,21 @@ private[akka] object N1qlQueryStage {
     def call(t: AsyncN1qlQueryResult): Observable[AsyncN1qlQueryRow] =
       t.rows()
   }
-
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[akka] final class N1qlQueryStage[S](live: Boolean,
-                                            settings: N1qlQueryStage.N1qlQuerySettings,
-                                            initialQuery: N1qlQuery,
-                                            bucket: AsyncBucket,
-                                            initialState: S,
-                                            nextQuery: S => Option[N1qlQuery],
-                                            updateState: (S, AsyncN1qlQueryRow) => S)
-    extends GraphStage[SourceShape[AsyncN1qlQueryRow]] {
-
+private[akka] final class N1qlQueryStage[S](
+    live: Boolean,
+    settings: N1qlQueryStage.N1qlQuerySettings,
+    initialQuery: N1qlQuery,
+    bucket: AsyncBucket,
+    initialState: S,
+    nextQuery: S => Option[N1qlQuery],
+    updateState: (S, AsyncN1qlQueryRow) => S
+) extends GraphStage[SourceShape[AsyncN1qlQueryRow]] {
   import N1qlQueryStage._
 
   val out: Outlet[AsyncN1qlQueryRow] = Outlet("LiveN1qlQuery.out")
@@ -72,10 +71,12 @@ private[akka] final class N1qlQueryStage[S](live: Boolean,
       }
 
       private val completeCb = getAsyncCallback[Unit] { _ =>
-        log.debug("Query complete. Remaining buffer: {}, rowsInCurrentQuery: {}, pageSize: {}",
-                  buffer,
-                  rowsInCurrentQuery,
-                  settings.pageSize)
+        log.debug(
+          "Query complete. Remaining buffer: {}, rowsInCurrentQuery: {}, pageSize: {}",
+          buffer,
+          rowsInCurrentQuery,
+          settings.pageSize
+        )
         if (rowsInCurrentQuery == settings.pageSize)
           state = IdleAfterFullPage
         else
@@ -186,5 +187,4 @@ private[akka] final class N1qlQueryStage[S](live: Boolean,
 
       setHandler(out, this)
     }
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/TagSequenceNumbering.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/TagSequenceNumbering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -35,7 +35,6 @@ import scala.concurrent.{ExecutionContext, Future}
   def nextTagSeqNrFor(pid: PersistenceId, tag: Tag): Future[Long] = {
     val key = (pid, tag)
     Option(taggingPerPidSequenceNumbers.get(key)) match {
-
       case Some(present) =>
         Future.successful(present)
         val newValue = present + 1
@@ -87,5 +86,4 @@ import scala.concurrent.{ExecutionContext, Future}
         case None => None
       }
     }
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/TimeBasedUUIDs.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/TimeBasedUUIDs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -15,9 +15,8 @@ import akka.annotation.InternalApi
  * INTERNAL API
  */
 @InternalApi private[akka] object TimeBasedUUIDs {
-
   val MinLSB = 0x0000000000000000L
-  val MaxLSB = 0x7f7f7f7f7f7f7f7fL
+  val MaxLSB = 0x7F7F7F7F7F7F7F7FL
 
   val MinUUID = create(UUIDTimestamp.MinVal, MinLSB)
   val MaxUUID = create(UUIDTimestamp.MaxVal, MaxLSB)
@@ -32,16 +31,15 @@ import akka.annotation.InternalApi
 
   def msbFromTimestamp(timestamp: UUIDTimestamp): Long = {
     var msb = 0L
-    msb |= (0x00000000ffffffffL & timestamp.nanoTimestamp) << 32
-    msb |= (0x0000ffff00000000L & timestamp.nanoTimestamp) >>> 16
-    msb |= (0x0fff000000000000L & timestamp.nanoTimestamp) >>> 48
+    msb |= (0x00000000FFFFFFFFL & timestamp.nanoTimestamp) << 32
+    msb |= (0x0000FFFF00000000L & timestamp.nanoTimestamp) >>> 16
+    msb |= (0x0FFF000000000000L & timestamp.nanoTimestamp) >>> 48
     msb |= 0x0000000000001000L // sets the version to 1.
     msb
   }
 
   def create(timestamp: UUIDTimestamp, lsb: Long): UUID =
     new UUID(msbFromTimestamp(timestamp), lsb)
-
 }
 
 /**
@@ -50,7 +48,6 @@ import akka.annotation.InternalApi
  * Comparator that sorts the same as the string format in TimeBasedUUIDSerialization
  */
 @InternalApi private[akka] final class TimeBasedUUIDComparator extends Comparator[UUID] {
-
   import java.lang.Long.compareUnsigned
 
   def compare(u1: UUID, u2: UUID): Int = {
@@ -63,7 +60,6 @@ import akka.annotation.InternalApi
     else
       // or if that won't work, by other bits lexically
       compareUnsigned(u1.getLeastSignificantBits, u2.getLeastSignificantBits)
-
   }
 }
 
@@ -78,7 +74,6 @@ import akka.annotation.InternalApi
  * INTERNAL API
  */
 @InternalApi private[akka] object TimeBasedUUIDSerialization {
-
   // very close to ISO 8660 since that is string-sortable, but including nanos
   private val SortableTimeFormatter = new DateTimeFormatterBuilder()
     .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)

--- a/core/src/main/scala/akka/persistence/couchbase/internal/UUIDGenerator.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/UUIDGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -18,7 +18,6 @@ import scala.util.Random
  */
 @InternalApi
 private[akka] object UUIDGenerator {
-
   def extractMac(): Long = {
     // use first interface we find
     def firstAvailableMac(enumeration: java.util.Enumeration[NetworkInterface]): Array[Byte] =
@@ -40,12 +39,12 @@ private[akka] object UUIDGenerator {
   }
 
   def macAsLong(addressArray: Array[Byte]): Long = {
-    var address = 0xffL & addressArray(5)
-    address |= (0xffL & addressArray(4)) << 8
-    address |= (0xffL & addressArray(3)) << 16
-    address |= (0xffL & addressArray(2)) << 24
-    address |= (0xffL & addressArray(1)) << 32
-    address |= (0xffL & addressArray(0)) << 40
+    var address = 0xFFL & addressArray(5)
+    address |= (0xFFL & addressArray(4)) << 8
+    address |= (0xFFL & addressArray(3)) << 16
+    address |= (0xFFL & addressArray(2)) << 24
+    address |= (0xFFL & addressArray(1)) << 32
+    address |= (0xFFL & addressArray(0)) << 40
     address
   }
 
@@ -72,7 +71,6 @@ private[akka] object UUIDGenerator {
  */
 @InternalApi
 private[akka] final class UUIDGenerator(clockSeqAndNode: Long) {
-
   // makes sure we don't return the same timestamp twice
   private val lastTimeStamp = new AtomicLong(0L)
 
@@ -91,9 +89,7 @@ private[akka] final class UUIDGenerator(clockSeqAndNode: Long) {
     if (now > last) {
       if (lastTimeStamp.compareAndSet(last.nanoTimestamp, now.nanoTimestamp)) now
       else currentTimestamp() // lost cas, try again
-
     } else {
-
       val lastMs = last.toMs
       val candidate = last.next
 
@@ -111,7 +107,6 @@ private[akka] final class UUIDGenerator(clockSeqAndNode: Long) {
       } else if (lastTimeStamp.compareAndSet(last.nanoTimestamp, candidate.nanoTimestamp)) {
         candidate
       } else currentTimestamp() // lost the cas, try again
-
     }
   }
 
@@ -119,5 +114,4 @@ private[akka] final class UUIDGenerator(clockSeqAndNode: Long) {
     val timestamp = currentTimestamp()
     TimeBasedUUIDs.create(timestamp, clockSeqAndNode)
   }
-
 }

--- a/core/src/main/scala/akka/persistence/couchbase/internal/UUIDTimestamp.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/internal/UUIDTimestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -14,7 +14,6 @@ import akka.annotation.InternalApi
  */
 @InternalApi
 private[akka] object UUIDTimestamp {
-
   val GMT = ZoneId.of("GMT")
 
   // UUID v1 timestamp must be in 100-nanoseconds interval since Oct 15 1582 00:00:00.000
@@ -48,7 +47,6 @@ private[akka] object UUIDTimestamp {
  */
 @InternalApi
 private[akka] final case class UUIDTimestamp(nanoTimestamp: Long) extends AnyVal with Ordered[UUIDTimestamp] {
-
   import UUIDTimestamp._
 
   /**

--- a/core/src/main/scala/akka/persistence/couchbase/javadsl/CouchbaseReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/javadsl/CouchbaseReadJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.javadsl
@@ -26,7 +26,6 @@ import scala.compat.java8.FutureConverters._
 import akka.dispatch.ExecutionContexts
 
 object CouchbaseReadJournal {
-
   /**
    * The default identifier for [[CouchbaseReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#getReadJournalFor`.
@@ -63,7 +62,6 @@ final class CouchbaseReadJournal(scaladslReadJournal: scaladsl.CouchbaseReadJour
     with CurrentEventsByTagQuery
     with CurrentPersistenceIdsQuery
     with PersistenceIdsQuery {
-
   /**
    * Data Access Object for arbitrary queries or updates.
    */
@@ -93,9 +91,11 @@ final class CouchbaseReadJournal(scaladslReadJournal: scaladsl.CouchbaseReadJour
    * Corresponding query that is completed when it reaches the end of the currently
    * stored events is provided by `currentEventsByPersistenceId`.
    */
-  override def eventsByPersistenceId(persistenceId: String,
-                                     fromSequenceNr: Long,
-                                     toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+  override def eventsByPersistenceId(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long
+  ): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
@@ -103,9 +103,11 @@ final class CouchbaseReadJournal(scaladslReadJournal: scaladsl.CouchbaseReadJour
    * is completed immediately when it reaches the end of the "result set". Events that are
    * stored after the query is completed are not included in the event stream.
    */
-  override def currentEventsByPersistenceId(persistenceId: String,
-                                            fromSequenceNr: Long,
-                                            toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+  override def currentEventsByPersistenceId(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long
+  ): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**

--- a/core/src/main/scala/akka/persistence/couchbase/scaladsl/CouchbaseReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/scaladsl/CouchbaseReadJournal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -37,7 +37,6 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 
 object CouchbaseReadJournal {
-
   /**
    * The default identifier for [[CouchbaseReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#getReadJournalFor`.
@@ -74,7 +73,6 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
     with CurrentPersistenceIdsQuery
     with PersistenceIdsQuery
     with CouchbaseSchema.Queries {
-
   private implicit val system = eas
   private val log = Logging(system, configPath)
 
@@ -109,7 +107,6 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
       session <- asyncSession
       indexes <- session.listIndexes().runWith(Sink.seq)
     } yield {
-
       val indexNames = indexes.map(_.name()).toSet
       Set("tags", "tag-seq-nrs").foreach(
         requiredIndex =>
@@ -117,7 +114,7 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
             log.warning(
               "Missing the [{}] index, the events by tag query will not work without it, see plugin documentation for details",
               requiredIndex
-          )
+            )
       )
     }
     checkF.onComplete(_ => materializer.shutdown())
@@ -385,7 +382,6 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
             EventEnvelope(Offset.timeBasedUUID(tpr.offset), tpr.pr.persistenceId, tpr.pr.sequenceNr, tpr.pr.payload) :: Nil
           }
         }
-
     }
 
   /**
@@ -445,6 +441,5 @@ final class CouchbaseReadJournal(eas: ExtendedActorSystem, config: Config, confi
           }
         }
       }
-
   }
 }

--- a/core/src/main/scala/akka/persistence/couchbase/settings.scala
+++ b/core/src/main/scala/akka/persistence/couchbase/settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -11,19 +11,20 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 
-final case class CouchbaseJournalSettings private (sessionSettings: CouchbaseSessionSettings,
-                                                   bucket: String,
-                                                   writeSettings: CouchbaseWriteSettings,
-                                                   replayPageSize: Int,
-                                                   readTimeout: FiniteDuration,
-                                                   warnAboutMissingIndexes: Boolean)
+final case class CouchbaseJournalSettings private (
+    sessionSettings: CouchbaseSessionSettings,
+    bucket: String,
+    writeSettings: CouchbaseWriteSettings,
+    replayPageSize: Int,
+    readTimeout: FiniteDuration,
+    warnAboutMissingIndexes: Boolean
+)
 
 /**
  * INTERNAL API
  */
 @InternalApi
 object CouchbaseJournalSettings {
-
   def apply(config: Config): CouchbaseJournalSettings = {
     val clientConfig = config.getConfig("connection")
     val bucket = config.getString("write.bucket")
@@ -33,12 +34,14 @@ object CouchbaseJournalSettings {
     val replayPageSize = config.getInt("write.replay-page-size")
     val warnAboutMissingIndexes = config.getBoolean("write.warn-about-missing-indexes")
 
-    CouchbaseJournalSettings(sessionSettings,
-                             bucket,
-                             writeSettings,
-                             replayPageSize,
-                             readTimeout,
-                             warnAboutMissingIndexes)
+    CouchbaseJournalSettings(
+      sessionSettings,
+      bucket,
+      writeSettings,
+      replayPageSize,
+      readTimeout,
+      warnAboutMissingIndexes
+    )
   }
 
   def parseWriteSettings(config: Config): CouchbaseWriteSettings =
@@ -72,13 +75,15 @@ object CouchbaseJournalSettings {
  * INTERNAL API
  */
 @InternalApi
-private[couchbase] final case class CouchbaseReadJournalSettings(sessionSettings: CouchbaseSessionSettings,
-                                                                 bucket: String,
-                                                                 pageSize: Int,
-                                                                 liveQueryInterval: FiniteDuration,
-                                                                 eventByTagSettings: EventByTagSettings,
-                                                                 dispatcher: String,
-                                                                 warnAboutMissingIndexes: Boolean)
+private[couchbase] final case class CouchbaseReadJournalSettings(
+    sessionSettings: CouchbaseSessionSettings,
+    bucket: String,
+    pageSize: Int,
+    liveQueryInterval: FiniteDuration,
+    eventByTagSettings: EventByTagSettings,
+    dispatcher: String,
+    warnAboutMissingIndexes: Boolean
+)
 final case class EventByTagSettings(eventualConsistencyDelay: FiniteDuration, getParallelism: Int)
 
 /**
@@ -86,7 +91,6 @@ final case class EventByTagSettings(eventualConsistencyDelay: FiniteDuration, ge
  */
 @InternalApi
 private[couchbase] object CouchbaseReadJournalSettings {
-
   def apply(config: Config): CouchbaseReadJournalSettings = {
     val clientConfig = config.getConfig("connection")
     val bucket = config.getString("write.bucket")
@@ -105,13 +109,15 @@ private[couchbase] object CouchbaseReadJournalSettings {
 
     val warnAboutMissingIndexes = config.getBoolean("write.warn-about-missing-indexes")
 
-    CouchbaseReadJournalSettings(sessionSettings,
-                                 bucket,
-                                 pageSize,
-                                 liveQueryInterval,
-                                 eventByTagSettings,
-                                 dispatcher,
-                                 warnAboutMissingIndexes)
+    CouchbaseReadJournalSettings(
+      sessionSettings,
+      bucket,
+      pageSize,
+      liveQueryInterval,
+      eventByTagSettings,
+      dispatcher,
+      warnAboutMissingIndexes
+    )
   }
 }
 
@@ -119,17 +125,18 @@ private[couchbase] object CouchbaseReadJournalSettings {
  * INTERNAL API
  */
 @InternalApi
-private[couchbase] final case class CouchbaseSnapshotSettings(sessionSettings: CouchbaseSessionSettings,
-                                                              bucket: String,
-                                                              writeSettings: CouchbaseWriteSettings,
-                                                              warnAboutMissingIndexes: Boolean)
+private[couchbase] final case class CouchbaseSnapshotSettings(
+    sessionSettings: CouchbaseSessionSettings,
+    bucket: String,
+    writeSettings: CouchbaseWriteSettings,
+    warnAboutMissingIndexes: Boolean
+)
 
 /**
  * INTERNAL API
  */
 @InternalApi
 private[couchbase] object CouchbaseSnapshotSettings {
-
   def apply(config: Config): CouchbaseSnapshotSettings = {
     val clientConfig = config.getConfig("connection")
     val bucket = config.getString("snapshot.bucket")

--- a/core/src/test/java/akka/persistence/couchbase/javadsl/CouchbaseReadJournalTest.java
+++ b/core/src/test/java/akka/persistence/couchbase/javadsl/CouchbaseReadJournalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.javadsl;
@@ -50,15 +50,15 @@ public class CouchbaseReadJournalTest {
     }
   }
 
-  static Config config = ConfigFactory.parseString(
-      "couchbase-journal.write.event-adapters { \n" +
-          "  test-tagger = \"akka.persistence.couchbase.javadsl.CouchbaseReadJournalTest$TestTagger\" \n" +
-          "} \n " +
-
-          "couchbase-journal.write.event-adapter-bindings { \n" +
-          "  \"java.lang.String\" = test-tagger \n" +
-          "} \n"
-  ).withFallback(ConfigFactory.load());
+  static Config config =
+      ConfigFactory.parseString(
+              "couchbase-journal.write.event-adapters { \n"
+                  + "  test-tagger = \"akka.persistence.couchbase.javadsl.CouchbaseReadJournalTest$TestTagger\" \n"
+                  + "} \n "
+                  + "couchbase-journal.write.event-adapter-bindings { \n"
+                  + "  \"java.lang.String\" = test-tagger \n"
+                  + "} \n")
+          .withFallback(ConfigFactory.load());
 
   static ActorSystem system;
   static ActorMaterializer mat;
@@ -72,12 +72,12 @@ public class CouchbaseReadJournalTest {
     mat = ActorMaterializer.create(system);
 
     // #read-journal-access
-    queries = PersistenceQuery.get(system)
-        .getReadJournalFor(CouchbaseReadJournal.class, CouchbaseReadJournal.Identifier());
+    queries =
+        PersistenceQuery.get(system)
+            .getReadJournalFor(CouchbaseReadJournal.class, CouchbaseReadJournal.Identifier());
     // #read-journal-access
 
-    clusterConnection = CouchbaseClusterConnection.connect()
-        .cleanUp();
+    clusterConnection = CouchbaseClusterConnection.connect().cleanUp();
 
     couchbaseSession = clusterConnection.couchbaseSession().asJava();
   }
@@ -101,74 +101,86 @@ public class CouchbaseReadJournalTest {
 
   @Test
   public void test01_startEventsByPersistenceIdQuery() {
-    new TestKit(system) {{
-      ActorRef a = system.actorOf(TestActor.props("a"));
-      a.tell("a-1", getRef());
-      expectMsg("a-1-done");
+    new TestKit(system) {
+      {
+        ActorRef a = system.actorOf(TestActor.props("a"));
+        a.tell("a-1", getRef());
+        expectMsg("a-1-done");
 
-      awaitAssert(() -> {
-        Source<String, NotUsed> src = queries
-            .eventsByPersistenceId("a", 0L, Long.MAX_VALUE)
-            .map(EventEnvelope::persistenceId);
+        awaitAssert(
+            () -> {
+              Source<String, NotUsed> src =
+                  queries
+                      .eventsByPersistenceId("a", 0L, Long.MAX_VALUE)
+                      .map(EventEnvelope::persistenceId);
 
-        TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
-        probe.request(10);
-        probe.expectNext("a");
-        return probe.cancel();
-      });
-    }};
+              TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
+              probe.request(10);
+              probe.expectNext("a");
+              return probe.cancel();
+            });
+      }
+    };
   }
 
   @Test
   public void test02_startCurrentEventsByPersistenceIdQuery() {
-    new TestKit(system) {{
-      ActorRef a = system.actorOf(TestActor.props("b"));
-      a.tell("b-1", getRef());
-      expectMsg("b-1-done");
+    new TestKit(system) {
+      {
+        ActorRef a = system.actorOf(TestActor.props("b"));
+        a.tell("b-1", getRef());
+        expectMsg("b-1-done");
 
-      awaitAssert(() -> {
-        Source<String, NotUsed> src = queries
-            .currentEventsByPersistenceId("b", 0L, Long.MAX_VALUE)
-            .map(EventEnvelope::persistenceId);
+        awaitAssert(
+            () -> {
+              Source<String, NotUsed> src =
+                  queries
+                      .currentEventsByPersistenceId("b", 0L, Long.MAX_VALUE)
+                      .map(EventEnvelope::persistenceId);
 
-        TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
-        probe.request(10);
-        probe.expectNext("b");
-        return probe.expectComplete();
-      });
-    }};
+              TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
+              probe.request(10);
+              probe.expectNext("b");
+              return probe.expectComplete();
+            });
+      }
+    };
   }
 
   @Test
   public void test03_StartEventsByTagQuery() {
-    new TestKit(system) {{
-      Source<String, NotUsed> src = queries
-          .eventsByTag("a", Offset.noOffset())
-          .map(EventEnvelope::persistenceId);
+    new TestKit(system) {
+      {
+        Source<String, NotUsed> src =
+            queries.eventsByTag("a", Offset.noOffset()).map(EventEnvelope::persistenceId);
 
-      awaitAssert(() -> {
-        TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
-        probe.request(10);
-        probe.expectNext("a");
-        probe.expectNoMessage(Duration.ofMillis(100));
-        return probe.cancel();
-      });
-    }};
+        awaitAssert(
+            () -> {
+              TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
+              probe.request(10);
+              probe.expectNext("a");
+              probe.expectNoMessage(Duration.ofMillis(100));
+              return probe.cancel();
+            });
+      }
+    };
   }
 
   @Test
   public void test04_startCurrentEventsByTagQuery() {
-    new TestKit(system) {{
-      Source<String, NotUsed> src = queries
-          .currentEventsByTag("a", Offset.noOffset())
-          .map(EventEnvelope::persistenceId);
+    new TestKit(system) {
+      {
+        Source<String, NotUsed> src =
+            queries.currentEventsByTag("a", Offset.noOffset()).map(EventEnvelope::persistenceId);
 
-      awaitAssert(() -> {
-        TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
-        probe.request(10);
-        probe.expectNext("a");
-        return probe.expectComplete();
-      });
-    }};
+        awaitAssert(
+            () -> {
+              TestSubscriber.Probe<String> probe = src.runWith(TestSink.<String>probe(system), mat);
+              probe.request(10);
+              probe.expectNext("a");
+              return probe.expectComplete();
+            });
+      }
+    };
   }
 }

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseBucketSetup.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseBucketSetup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -22,5 +22,4 @@ trait CouchbaseBucketSetup extends BeforeAndAfterAll { self: Suite =>
     clusterConnection.close()
     super.afterAll()
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseClusterConnection.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseClusterConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -15,11 +15,9 @@ import scala.util.Try
 import scala.concurrent.duration._
 
 object CouchbaseClusterConnection {
-
   def connect(): CouchbaseClusterConnection = connect("admin", "admin1", "akka")
 
   def connect(username: String, password: String, bucketName: String): CouchbaseClusterConnection = {
-
     val cluster = CouchbaseCluster.create()
     cluster.authenticate(username, password) // needs to be admin
 
@@ -27,11 +25,9 @@ object CouchbaseClusterConnection {
 
     new CouchbaseClusterConnection(cluster, bucket)
   }
-
 }
 
 final class CouchbaseClusterConnection(val cluster: Cluster, bucket: Bucket) {
-
   val couchbaseSession: CouchbaseSession = CouchbaseSession(bucket)
 
   def cleanUp(): CouchbaseClusterConnection = {

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -26,9 +26,7 @@ class CouchbaseJournalIntegrationSpec
     with Matchers
     with CouchbaseBucketSetup
     with WithLogCapturing {
-
   "The Couchbase Journal" must {
-
     "always replay to the latest written event" in {
       // even with outstanding writes - covers #140, and also that replay of a longer journal works
       val ref1 = system.actorOf(TestActor.props("latest-written"))
@@ -45,7 +43,5 @@ class CouchbaseJournalIntegrationSpec
       ref2 ! TestActor.GetLastRecoveredEvent
       expectMsg(10.seconds, "500")
     }
-
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalPerfSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalPerfSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -22,7 +22,6 @@ class CouchbaseJournalPerfSpec
         """).withFallback(ConfigFactory.load()))
     with CouchbaseBucketSetup
     with WithLogCapturing {
-
   override def awaitDurationMillis: Long = 20.seconds.toMillis
 
   // We want to test with persisting guaranteed, which makes

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseJournalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -21,7 +21,6 @@ class CouchbaseJournalSpec
     )
     with CouchbaseBucketSetup
     with WithLogCapturing {
-
   override def supportsRejectingNonSerializableObjects: CapabilityFlag =
     false // or CapabilityFlag.off
 

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseReplaySpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseReplaySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -11,12 +11,13 @@ import com.couchbase.client.java.document.JsonDocument
 import com.typesafe.config.ConfigFactory
 
 class CouchbaseReplaySpec
-    extends AbstractCouchbaseSpec("CouchbaseReplaySpec",
-                                  ConfigFactory.parseString("""
+    extends AbstractCouchbaseSpec(
+      "CouchbaseReplaySpec",
+      ConfigFactory.parseString("""
  akka.loggers = [akka.testkit.TestEventListener]
-  """.stripMargin))
+  """.stripMargin)
+    )
     with CouchbaseBucketSetup {
-
   "Replay" must {
     "fail if next document found" in new Setup {
       override def initialPersistedEvents: Int = 2
@@ -27,11 +28,12 @@ class CouchbaseReplaySpec
 
       couchbaseSession.insert(JsonDocument.create(s"$pid-3")).futureValue
 
-      EventFilter[RuntimeException](message = "Read highest sequence nr 2 but found document with id 1-3",
-                                    occurrences = 1).intercept {
+      EventFilter[RuntimeException](
+        message = "Read highest sequence nr 2 but found document with id 1-3",
+        occurrences = 1
+      ).intercept {
         system.actorOf(TestActor.props(pid))
       }
     }
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseSnapshotSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseSnapshotSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -27,7 +27,6 @@ class CouchbaseSnapshotSpec
     with CouchbaseBucketSetup
     with BeforeAndAfterEach
     with WithLogCapturing {
-
   protected override def afterAll(): Unit = {
     super.afterAll()
     shutdown(system)
@@ -81,5 +80,4 @@ class CouchbaseSnapshotSpec
       }
     }
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/CouchbaseSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/CouchbaseSnapshotStoreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase

--- a/core/src/test/scala/akka/persistence/couchbase/SerializationSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/SerializationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -21,7 +21,6 @@ case class MyEventAsync(n: Int)
 case class MyEventNative(n: Int)
 
 class MyEventAsyncSerializer(system: ExtendedActorSystem) extends AsyncSerializerWithStringManifest(system) {
-
   import system.dispatcher
 
   override def identifier: Int = 1984
@@ -40,7 +39,6 @@ class MyEventAsyncSerializer(system: ExtendedActorSystem) extends AsyncSerialize
         case "Woo!" => MyEventAsync(BigInt(bytes).toInt)
       }
     }
-
 }
 
 class MyEventNativeJsonSerializer extends JsonSerializer {
@@ -61,7 +59,6 @@ class MyEventNativeJsonSerializer extends JsonSerializer {
 }
 
 class SerializationSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
-
   implicit val system = ActorSystem(
     "SerializationSpec",
     ConfigFactory.parseString("""
@@ -76,7 +73,6 @@ class SerializationSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
   val serialization = SerializationExtension(system)
 
   "The serialization of events" must {
-
     "serialize and deserialize events" in {
       val event = MyEvent(42)
       val serializedEvent = SerializedMessage.serialize(serialization, event).futureValue
@@ -104,7 +100,6 @@ class SerializationSpec extends WordSpec with Matchers with BeforeAndAfterAll wi
       val deserialized = SerializedMessage.fromJsonObject(serialization, json).futureValue
       deserialized should ===(event)
     }
-
   }
 
   override def afterAll(): Unit =

--- a/core/src/test/scala/akka/persistence/couchbase/TestActor.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/TestActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -27,7 +27,6 @@ object TestActor {
 class TestActor(override val persistenceId: String, override val journalPluginId: String)
     extends PersistentActor
     with ActorLogging {
-
   var lastDelete: ActorRef = _
   var lastRecoveredEvent: String = _
 
@@ -37,7 +36,6 @@ class TestActor(override val persistenceId: String, override val journalPluginId
 
     case RecoveryCompleted =>
       log.debug("Recovery completed, lastRecoveredEvent: {}", lastRecoveredEvent)
-
   }
 
   val receiveCommand: Receive = {
@@ -55,12 +53,11 @@ class TestActor(override val persistenceId: String, override val journalPluginId
       val size = events.size
       val handler = {
         var count = 0
-        _: String =>
-          {
-            count += 1
-            if (count == size)
-              sender() ! "PersistAll-done"
-          }
+        _: String => {
+          count += 1
+          if (count == size)
+            sender() ! "PersistAll-done"
+        }
       }
       persistAll(events)(handler)
 
@@ -68,12 +65,11 @@ class TestActor(override val persistenceId: String, override val journalPluginId
       val size = events.size
       val handler = {
         var count = 0
-        evt: String =>
-          {
-            count += 1
-            if (count == size)
-              sender() ! "PersistAllAsync-done"
-          }
+        evt: String => {
+          count += 1
+          if (count == size)
+            sender() ! "PersistAllAsync-done"
+        }
       }
       persistAllAsync(events)(handler)
       sender() ! "PersistAllAsync-triggered"

--- a/core/src/test/scala/akka/persistence/couchbase/UUIDsSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/UUIDsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase
@@ -10,7 +10,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
 class UUIDsSpec extends WordSpec with Matchers with ScalaFutures {
-
   "UUIDs factory" should {
     "return NoOffset for zero timestamp" in {
       UUIDs.timeBasedUUIDFrom(0) should ===(NoOffset)

--- a/core/src/test/scala/akka/persistence/couchbase/internal/FutureUtilsSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/internal/FutureUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -12,9 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class FutureUtilsSpec extends WordSpec with Matchers with ScalaFutures {
-
   "The future utils" must {
-
     "allow for sequential traversal" in {
       @volatile var counter = -1
 
@@ -24,7 +22,7 @@ class FutureUtilsSpec extends WordSpec with Matchers with ScalaFutures {
             Future {
               counter += 1
               (n, counter)
-          }
+            }
         )
         .futureValue
 
@@ -32,8 +30,6 @@ class FutureUtilsSpec extends WordSpec with Matchers with ScalaFutures {
         case (n, c) =>
           n should ===(c)
       }
-
     }
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/internal/UUIDSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/internal/UUIDSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.internal
@@ -14,11 +14,9 @@ import scala.math.Ordering.comparatorToOrdering
 import scala.util.Random
 
 class UUIDSpec extends WordSpec with Matchers with ScalaFutures {
-
   override implicit def patienceConfig = PatienceConfig(5.seconds, 50.millis)
 
   "The time based UUIDs" should {
-
     "roundtrip a unix timestamp back into itself" in {
       val unixTimestamp = 1543410889L
       val result = UUIDTimestamp.fromUnixTimestamp(unixTimestamp).toUnixTimestamp

--- a/core/src/test/scala/akka/persistence/couchbase/scaladsl/AbstractCouchbaseSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/scaladsl/AbstractCouchbaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -25,7 +25,6 @@ abstract class AbstractCouchbaseSpec(testName: String, config: Config)
     with ScalaFutures
     with CouchbaseBucketSetup
     with WithLogCapturing {
-
   def this(testName: String) =
     this(
       testName,
@@ -84,5 +83,4 @@ abstract class AbstractCouchbaseSpec(testName: String, config: Config)
     super.afterAll()
     shutdown(system)
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/scaladsl/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/scaladsl/EventsByPersistenceIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -11,9 +11,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.testkit.scaladsl.TestSink
 
 class EventsByPersistenceIdSpec extends AbstractCouchbaseSpec("EventsByPersistenceIdSpec") {
-
   "Couchbase query EventsByPersistenceId" must {
-
     "find existing events" in new Setup {
       override def initialPersistedEvents = 3
 
@@ -119,7 +117,6 @@ class EventsByPersistenceIdSpec extends AbstractCouchbaseSpec("EventsByPersisten
         .request(5)
         .expectNext(s"$pid-3")
         .expectComplete() // e-4 not seen
-
     }
 
     "not see new events after the query was triggered, across page size" in new Setup {
@@ -167,7 +164,6 @@ class EventsByPersistenceIdSpec extends AbstractCouchbaseSpec("EventsByPersisten
         // last events that was in db when query was triggered
         .expectNextN(expectedEvents)
         .expectComplete() // but not the event that was written after query is not seen
-
     }
 
     "only deliver what requested if there is more in the buffer" in new Setup {
@@ -266,11 +262,9 @@ class EventsByPersistenceIdSpec extends AbstractCouchbaseSpec("EventsByPersisten
         streamProbe.expectComplete()
       }
     }
-
   }
 
   "Couchbase live query EventsByPersistenceId" must {
-
     "find new events" in new Setup {
       override def initialPersistedEvents = 3
       val streamProbe = readingOurOwnWrites {

--- a/core/src/test/scala/akka/persistence/couchbase/scaladsl/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/scaladsl/EventsByTagSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -16,7 +16,6 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 
 class Tagger extends WriteEventAdapter {
-
   override def toJournal(event: Any): Any = event match {
     case s: String =>
       val regex = """tag-\w+""".r
@@ -30,7 +29,6 @@ class Tagger extends WriteEventAdapter {
 }
 
 class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
-
   // use unique tags for each test to isolate
   var tagCounter = 0
   private def newTag(): String = {
@@ -39,7 +37,6 @@ class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
   }
 
   "liveEventsByTag" must {
-
     "find new events" in new Setup {
       val (_, a1) = startPersistentActor(0)
       val (pid2, a2) = startPersistentActor(0)
@@ -89,7 +86,6 @@ class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
     }
 
     "find events from offset " in new Setup {
-
       val (pid1, a1) = startPersistentActor(0)
       val (pid2, a2) = startPersistentActor(0)
       val (_, a3) = startPersistentActor(0) // don't use until after query started
@@ -207,7 +203,6 @@ class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
     }
 
     "stream many events" in new Setup {
-
       val tag = newTag()
       system.log.debug("tag: {}", tag)
 
@@ -291,7 +286,6 @@ class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
     }
 
     "find existing events with an offset into an atomic write" in new Setup {
-
       val tag1 = newTag()
       val tag2 = newTag()
       system.log.debug("tag1: {}, tag2: {}", tag1, tag2)
@@ -390,9 +384,6 @@ class EventsByTagSpec extends AbstractCouchbaseSpec("EventsByTagSpec") {
 
       ref1 ! TestActor.Stop
       ref2 ! TestActor.Stop
-
     }
-
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/scaladsl/PersistenceIdsQuerySpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/scaladsl/PersistenceIdsQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -12,10 +12,8 @@ import akka.testkit.TestProbe
 import scala.concurrent.duration._
 
 class PersistenceIdsQuerySpec extends AbstractCouchbaseSpec("PersistenceIdsQuerySpec") {
-
   "currentPersistenceIds" must {
     "work" in {
-
       val senderProbe = TestProbe()
       implicit val sender = senderProbe.ref
       val pa1 = system.actorOf(TestActor.props("p1"))
@@ -35,7 +33,6 @@ class PersistenceIdsQuerySpec extends AbstractCouchbaseSpec("PersistenceIdsQuery
         },
         readOurOwnWritesTimeout
       )
-
     }
   }
 
@@ -65,8 +62,6 @@ class PersistenceIdsQuerySpec extends AbstractCouchbaseSpec("PersistenceIdsQuery
       queryProbe.expectNext("p4")
       // also not after p4 (it could come out of order)
       queryProbe.expectNoMessage(noMsgTimeout)
-
     }
   }
-
 }

--- a/core/src/test/scala/akka/persistence/couchbase/scaladsl/TagSequenceNumberSpec.scala
+++ b/core/src/test/scala/akka/persistence/couchbase/scaladsl/TagSequenceNumberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.persistence.couchbase.scaladsl
@@ -23,7 +23,6 @@ class TagSequenceNumberSpec
     with AsyncCouchbaseSession
     with Queries
     with TagSequenceNumbering {
-
   // for using TagSequenceNumbering to verify tag seq nrs
   def log = system.log
   protected def queryConsistency = N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS)
@@ -32,7 +31,6 @@ class TagSequenceNumberSpec
   implicit def executionContext = system.dispatcher
 
   "events by tag sequence numbering" must {
-
     "be monotonic and without holes when actor is stopped and restarted" in new Setup {
       val tag1 = "tag-1"
       val tag2 = "tag-2"
@@ -69,7 +67,6 @@ class TagSequenceNumberSpec
           currentTagSeqNrFromDb(pid, tag1).futureValue should ===(Some(3 * restartN))
         }
       }
-
     }
 
     "cause query to fail when there are gaps" in {
@@ -130,7 +127,5 @@ class TagSequenceNumberSpec
       val error = streamProbe.expectError() // should fail because of the gap
       error shouldBe an[OutOfOrderEventException]
     }
-
   }
-
 }

--- a/core/src/test/scala/akka/testkit/WithLogCapturing.scala
+++ b/core/src/test/scala/akka/testkit/WithLogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.testkit

--- a/docs/src/test/java/jdocs/home/persistence/CouchbaseReadSideQuery.java
+++ b/docs/src/test/java/jdocs/home/persistence/CouchbaseReadSideQuery.java
@@ -1,6 +1,10 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package jdocs.home.persistence;
 
-//#imports
+// #imports
 import akka.NotUsed;
 import akka.stream.alpakka.couchbase.javadsl.CouchbaseSession;
 import com.couchbase.client.java.document.json.JsonObject;
@@ -12,8 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
-
-//#imports
+// #imports
 
 public interface CouchbaseReadSideQuery {
 
@@ -21,7 +24,7 @@ public interface CouchbaseReadSideQuery {
     ServiceCall<NotUsed, List<UserGreeting>> userGreetings();
   }
 
-  //#service-impl
+  // #service-impl
   public class GreetingServiceImpl implements GreetingService {
 
     private final CouchbaseSession session;
@@ -33,49 +36,54 @@ public interface CouchbaseReadSideQuery {
 
     @Override
     public ServiceCall<NotUsed, List<UserGreeting>> userGreetings() {
-      return request -> session.get("users-actual-greetings")
-          .thenApply(docOpt -> {
-            if (docOpt.isPresent()) {
-              JsonObject content = docOpt.get().content();
-              return content.getNames().stream().map(
-                  name -> new UserGreeting(name, content.getString(name))
-              ).collect(Collectors.toList());
-            } else {
-              return Collections.emptyList();
-            }
-          });
+      return request ->
+          session
+              .get("users-actual-greetings")
+              .thenApply(
+                  docOpt -> {
+                    if (docOpt.isPresent()) {
+                      JsonObject content = docOpt.get().content();
+                      return content.getNames().stream()
+                          .map(name -> new UserGreeting(name, content.getString(name)))
+                          .collect(Collectors.toList());
+                    } else {
+                      return Collections.emptyList();
+                    }
+                  });
     }
   }
-  //#service-impl
+  // #service-impl
 
   static class Wrap {
     public class GreetingServiceImpl implements GreetingService {
 
       private final CouchbaseSession session;
 
-      //#register-event-processor
+      // #register-event-processor
       @Inject
       public GreetingServiceImpl(CouchbaseSession couchbaseSession, ReadSide readSide) {
         this.session = couchbaseSession;
         readSide.register(CouchbaseHelloEventProcessor.HelloEventProcessor.class);
       }
-      //#register-event-processor
+      // #register-event-processor
 
       @Override
       public ServiceCall<NotUsed, List<UserGreeting>> userGreetings() {
-        return request -> session.get("users-actual-greetings")
-            .thenApply(docOpt -> {
-              if (docOpt.isPresent()) {
-                JsonObject content = docOpt.get().content();
-                return content.getNames().stream().map(
-                    name -> new UserGreeting(name, content.getString(name))
-                ).collect(Collectors.toList());
-              } else {
-                return Collections.emptyList();
-              }
-            });
+        return request ->
+            session
+                .get("users-actual-greetings")
+                .thenApply(
+                    docOpt -> {
+                      if (docOpt.isPresent()) {
+                        JsonObject content = docOpt.get().content();
+                        return content.getNames().stream()
+                            .map(name -> new UserGreeting(name, content.getString(name)))
+                            .collect(Collectors.toList());
+                      } else {
+                        return Collections.emptyList();
+                      }
+                    });
       }
     }
   }
-
 }

--- a/docs/src/test/java/jdocs/home/persistence/HelloEvent.java
+++ b/docs/src/test/java/jdocs/home/persistence/HelloEvent.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package jdocs.home.persistence;
 
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent;

--- a/docs/src/test/java/jdocs/home/persistence/UserGreeting.java
+++ b/docs/src/test/java/jdocs/home/persistence/UserGreeting.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package jdocs.home.persistence;
 
 import java.util.Objects;
@@ -24,8 +28,7 @@ public final class UserGreeting {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     UserGreeting that = (UserGreeting) o;
-    return Objects.equals(user, that.user) &&
-        Objects.equals(message, that.message);
+    return Objects.equals(user, that.user) && Objects.equals(message, that.message);
   }
 
   @Override

--- a/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideProcessor.scala
+++ b/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideProcessor.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package docs.home.persistence
 
 // #imports
@@ -18,7 +19,6 @@ import scala.concurrent.{ExecutionContext, Future}
 object CouchbaseReadSideProcessorInitial {
   //#initial
   class HelloEventProcessor extends ReadSideProcessor[HelloEvent] {
-
     override def buildHandler(): ReadSideProcessor.ReadSideHandler[HelloEvent] =
       // TODO build read side handler
       ???
@@ -31,10 +31,8 @@ object CouchbaseReadSideProcessorInitial {
 }
 
 object CouchbaseReadSideProcessorTwo {
-
   class HelloEventProcessor(readSide: CouchbaseReadSide)(implicit executionContext: ExecutionContext)
       extends ReadSideProcessor[HelloEvent] {
-
     //#tag
     override def aggregateTags: Set[AggregateEventTag[HelloEvent]] = HelloEvent.Tag.allTags
     //#tag
@@ -82,8 +80,10 @@ object CouchbaseReadSideProcessorTwo {
     }
 
     // #greeting-message-changed
-    def processGreetingMessageChanged(session: CouchbaseSession,
-                                      ese: EventStreamElement[HelloEvent.GreetingChanged]): Future[Done] =
+    def processGreetingMessageChanged(
+        session: CouchbaseSession,
+        ese: EventStreamElement[HelloEvent.GreetingChanged]
+    ): Future[Done] =
       session
         .get(DocId)
         .flatMap { maybeDoc =>
@@ -97,6 +97,5 @@ object CouchbaseReadSideProcessorTwo {
         }
         .map(_ => Done)
     // #greeting-message-changed
-
   }
 }

--- a/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideQuery.scala
+++ b/docs/src/test/scala/docs/home/persistence/CouchbaseReadSideQuery.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package docs.home.persistence
 
 // #imports
@@ -17,7 +18,6 @@ import scala.concurrent.ExecutionContext
 // #imports
 
 object CouchbaseReadSideQuery {
-
   trait GreetingService extends Service {
     def userGreetings(): ServiceCall[NotUsed, List[UserGreeting]]
 

--- a/docs/src/test/scala/docs/home/persistence/HelloEvent.scala
+++ b/docs/src/test/scala/docs/home/persistence/HelloEvent.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package docs.home.persistence
 import com.lightbend.lagom.scaladsl.persistence.{AggregateEvent, AggregateEventShards, AggregateEventTag}
 

--- a/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseConfigValidator.scala
+++ b/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseConfigValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase
@@ -8,7 +8,6 @@ import akka.event.LoggingAdapter
 import com.typesafe.config.Config
 
 private[lagom] object CouchbaseConfigValidator {
-
   def validateBucket(namespace: String, config: Config, log: LoggingAdapter): Unit =
     if (log.isErrorEnabled) {
       val bucketPath = s"$namespace.bucket"

--- a/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseOffsetStore.scala
+++ b/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseOffsetStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase
@@ -28,18 +28,17 @@ private[lagom] object CouchbaseOffsetStore {
 
   val SequenceOffsetField = "sequenceOffset"
   val UuidOffsetField = "uuidOffset"
-
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[lagom] abstract class CouchbaseOffsetStore(system: ActorSystem,
-                                                   config: ReadSideConfig,
-                                                   couchbase: CouchbaseSession)
-    extends OffsetStore {
-
+private[lagom] abstract class CouchbaseOffsetStore(
+    system: ActorSystem,
+    config: ReadSideConfig,
+    couchbase: CouchbaseSession
+) extends OffsetStore {
   import CouchbaseOffsetStore._
   import system.dispatcher
 
@@ -63,20 +62,19 @@ private[lagom] abstract class CouchbaseOffsetStore(system: ActorSystem,
         new CouchbaseOffsetDao(couchbase, eventProcessorId, tag, offset, system.dispatcher)
     }
   }
-
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[lagom] final class CouchbaseOffsetDao(couchbase: CouchbaseSession,
-                                              eventProcessorId: String,
-                                              tag: String,
-                                              override val loadedOffset: Offset,
-                                              ec: ExecutionContext)
-    extends OffsetDao {
-
+private[lagom] final class CouchbaseOffsetDao(
+    couchbase: CouchbaseSession,
+    eventProcessorId: String,
+    tag: String,
+    override val loadedOffset: Offset,
+    ec: ExecutionContext
+) extends OffsetDao {
   override def saveOffset(offset: Offset): Future[Done] = bindSaveOffset(offset).execute(couchbase, ec)
 
   // FIXME write guarantees
@@ -107,5 +105,4 @@ private[lagom] final class CouchbaseOffsetDao(couchbase: CouchbaseSession,
           }
         }
     }
-
 }

--- a/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseReadSideSettings.scala
+++ b/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseReadSideSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase
@@ -10,4 +10,4 @@ import akka.actor.ActorSystem
 /**
  * Internal API
  */
-private[lagom] class CouchbaseReadSideSettings @Inject()(system: ActorSystem) {}
+private[lagom] class CouchbaseReadSideSettings @Inject() (system: ActorSystem) {}

--- a/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/ServiceLocatorHolder.scala
+++ b/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/internal/persistence/couchbase/ServiceLocatorHolder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase

--- a/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseAction.scala
+++ b/lagom-persistence-couchbase/core/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase

--- a/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseConfigValidatorSpec.scala
+++ b/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/CouchbaseConfigValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase
@@ -16,7 +16,6 @@ import scala.concurrent.Await
 class MyException extends RuntimeException("MyException")
 
 class CouchbaseConfigValidatorSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
-
   val akkaTestLogging = ConfigFactory.parseString("akka.loggers = [akka.testkit.TestEventListener]")
   implicit val system = ActorSystem("test", akkaTestLogging)
   val log = Logging(system, classOf[CouchbaseConfigValidatorSpec])

--- a/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/ServiceLocatorHolderSpec.scala
+++ b/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/ServiceLocatorHolderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase

--- a/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/TestConfig.scala
+++ b/lagom-persistence-couchbase/core/src/test/scala/com/lightbend/lagom/internal/persistence/couchbase/TestConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.persistence.couchbase
@@ -8,7 +8,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import scala.collection.JavaConverters._
 
 object TestConfig {
-
   val ClusterConfig = """
     akka.actor.provider: cluster
     akka.remote.netty.tcp.hostname: 127.0.0.1

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbasePersistentEntityRegistry.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbasePersistentEntityRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.javadsl.persistence.couchbase
@@ -18,14 +18,12 @@ import play.api.inject.Injector
  * Internal API
  */
 @Singleton
-private[lagom] final class CouchbasePersistentEntityRegistry @Inject()(system: ActorSystem, injector: Injector)
+private[lagom] final class CouchbasePersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
     extends AbstractPersistentEntityRegistry(system, injector) {
-
   private val log = Logging.getLogger(system, getClass)
 
   CouchbaseConfigValidator.validateBucket("couchbase-journal.write", system.settings.config, log)
   CouchbaseConfigValidator.validateBucket("couchbase-journal.snapshot", system.settings.config, log)
 
   override protected val queryPluginId = Optional.of(CouchbaseReadJournal.Identifier)
-
 }

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbaseReadSideHandler.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbaseReadSideHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.javadsl.persistence.couchbase
@@ -45,7 +45,6 @@ private[couchbase] final class CouchbaseReadSideHandler[Event <: AggregateEvent[
     dispatcher: String
 )(implicit ec: ExecutionContext)
     extends ReadSideHandler[Event] {
-
   private val log = LoggerFactory.getLogger(this.getClass)
 
   @volatile
@@ -92,7 +91,6 @@ private[couchbase] final class CouchbaseReadSideHandler[Event <: AggregateEvent[
           )
 
         invoke(handler, event, offset).toScala
-
       }
       .withAttributes(ActorAttributes.dispatcher(dispatcher))
       .asJava

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbaseReadSideImpl.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/CouchbaseReadSideImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.javadsl.persistence.couchbase
@@ -18,13 +18,12 @@ import javax.inject.{Inject, Singleton}
 import play.api.inject.Injector
 
 @Singleton
-private[lagom] class CouchbaseReadSideImpl @Inject()(
+private[lagom] class CouchbaseReadSideImpl @Inject() (
     system: ActorSystem,
     couchbaseSession: CouchbaseSession,
     offsetStore: CouchbaseOffsetStore,
     injector: Injector
 ) extends CouchbaseReadSide {
-
   private val dispatcher = system.settings.config.getString("lagom.persistence.read-side.use-dispatcher")
   private implicit val ec: MessageDispatcher = system.dispatchers.lookup(dispatcher)
 
@@ -32,7 +31,6 @@ private[lagom] class CouchbaseReadSideImpl @Inject()(
       readSideId: String
   ): CouchbaseReadSide.ReadSideHandlerBuilder[Event] =
     new CouchbaseReadSide.ReadSideHandlerBuilder[Event] {
-
       type Handler[E] = CouchbaseReadSideHandler.Handler[E]
 
       private var globalPrepareCallback: CouchbaseSession => CompletionStage[Done] =
@@ -74,12 +72,14 @@ private[lagom] class CouchbaseReadSideImpl @Inject()(
       }
 
       override def build(): ReadSideProcessor.ReadSideHandler[Event] =
-        new CouchbaseReadSideHandler[Event](couchbaseSession,
-                                            offsetStore,
-                                            handlers,
-                                            globalPrepareCallback,
-                                            prepareCallback,
-                                            readSideId,
-                                            dispatcher)
+        new CouchbaseReadSideHandler[Event](
+          couchbaseSession,
+          offsetStore,
+          handlers,
+          globalPrepareCallback,
+          prepareCallback,
+          readSideId,
+          dispatcher
+        )
     }
 }

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/JavadslCouchbaseOffsetStore.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/couchbase/JavadslCouchbaseOffsetStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.javadsl.persistence.couchbase
@@ -14,7 +14,8 @@ import javax.inject.{Inject, Singleton}
  * Internal API
  */
 @Singleton
-private[lagom] final class JavadslCouchbaseOffsetStore @Inject()(system: ActorSystem,
-                                                                 couchbase: CouchbaseSession,
-                                                                 config: ReadSideConfig)
-    extends CouchbaseOffsetStore(system, config, couchbase.asScala)
+private[lagom] final class JavadslCouchbaseOffsetStore @Inject() (
+    system: ActorSystem,
+    couchbase: CouchbaseSession,
+    config: ReadSideConfig
+) extends CouchbaseOffsetStore(system, config, couchbase.asScala)

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceGuiceModule.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceGuiceModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase
@@ -15,7 +15,6 @@ import com.google.inject.{AbstractModule, TypeLiteral}
  * InitServiceLocatorHolder, since Guice doesn't support @PostConstruct.
  */
 class CouchbasePersistenceGuiceModule extends AbstractModule {
-
   override def configure(): Unit =
     initServiceLocatorHolder()
 

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceModule.scala
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase
@@ -39,7 +39,6 @@ import scala.util.Try
  * Guice module for the Persistence API.
  */
 class CouchbasePersistenceModule extends Module {
-
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[CouchbasePersistenceModule.InitServiceLocatorHolder].toSelf.eagerly(),
     bind[PersistentEntityRegistry].to[CouchbasePersistentEntityRegistry],
@@ -50,11 +49,9 @@ class CouchbasePersistenceModule extends Module {
     bind[CouchbaseOffsetStore].to(bind[JavadslCouchbaseOffsetStore]),
     bind[OffsetStore].to(bind[CouchbaseOffsetStore])
   )
-
 }
 
-private[lagom] class CouchbaseProvider @Inject()(system: ActorSystem, cfg: Config) extends Provider[CouchbaseSession] {
-
+private[lagom] class CouchbaseProvider @Inject() (system: ActorSystem, cfg: Config) extends Provider[CouchbaseSession] {
   private val log = Logging(system, classOf[CouchbaseProvider])
 
   CouchbaseConfigValidator.validateBucket("lagom.persistence.read-side.couchbase", cfg, log)
@@ -79,9 +76,7 @@ private[lagom] class CouchbaseProvider @Inject()(system: ActorSystem, cfg: Confi
 }
 
 private[lagom] object CouchbasePersistenceModule {
-
-  class InitServiceLocatorHolder @Inject()(system: ActorSystem, injector: Injector) {
-
+  class InitServiceLocatorHolder @Inject() (system: ActorSystem, injector: Injector) {
     def init(): Unit =
       Try(injector.instanceOf[ServiceLocator]).foreach { locator =>
         ServiceLocatorHolder(system).setServiceLocator(new ServiceLocatorAdapter {
@@ -95,5 +90,4 @@ private[lagom] object CouchbasePersistenceModule {
         })
       }
   }
-
 }

--- a/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseReadSide.java
+++ b/lagom-persistence-couchbase/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseReadSide.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase;

--- a/lagom-persistence-couchbase/javadsl/src/multi-jvm/java/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/javadsl/src/multi-jvm/java/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseClusteredPersistentEntitySpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package com.lightbend.lagom.javadsl.persistence.couchbase
 
 import java.util.concurrent.CompletionStage
@@ -25,7 +29,6 @@ class CouchbaseClusteredPersistentEntitySpecMultiJvmNode3 extends CouchbaseClust
 
 class CouchbaseClusteredPersistentEntitySpec
     extends AbstractClusteredPersistentEntitySpec(CouchbaseClusteredPersistentEntityConfig) {
-
   import com.lightbend.lagom.javadsl.persistence.couchbase.CouchbaseClusteredPersistentEntityConfig._
 
   override protected def atStartup(): Unit = {

--- a/lagom-persistence-couchbase/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/lagom-persistence-couchbase/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence;
@@ -47,12 +47,9 @@ public class PersistentEntityRefTest {
 
   @BeforeClass
   public static void setup() {
-    Config config = TestConfig.clusterConfig()
-        .withFallback(TestConfig.persistenceConfig());
+    Config config = TestConfig.clusterConfig().withFallback(TestConfig.persistenceConfig());
 
-    application = new GuiceApplicationBuilder()
-        .configure(config)
-        .build();
+    application = new GuiceApplicationBuilder().configure(config).build();
     injector = application.injector();
 
     ActorSystem system = injector.instanceOf(ActorSystem.class);
@@ -62,8 +59,7 @@ public class PersistentEntityRefTest {
     awaitPersistenceInit(system);
 
     // TODO reuse parts of akka.persistence.couchbase.CouchbaseBucketSetup
-    couchbaseCluster = CouchbaseCluster.create()
-        .authenticate("admin", "admin1");
+    couchbaseCluster = CouchbaseCluster.create().authenticate("admin", "admin1");
     bucket = couchbaseCluster.openBucket("akka");
     bucket.bucketManager().createN1qlPrimaryIndex(true, false);
     bucket.query(N1qlQuery.simple("delete from akka"));
@@ -124,8 +120,10 @@ public class PersistentEntityRefTest {
 
   @Test(expected = AskTimeoutException.class)
   public void testAskTimeout() throws Throwable {
-    PersistentEntityRef<Cmd> ref = registry().refFor(TestEntity.class, "10").withAskTimeout(
-        FiniteDuration.create(1, MILLISECONDS));
+    PersistentEntityRef<Cmd> ref =
+        registry()
+            .refFor(TestEntity.class, "10")
+            .withAskTimeout(FiniteDuration.create(1, MILLISECONDS));
 
     List<CompletionStage<Evt>> replies = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
@@ -181,5 +179,4 @@ public class PersistentEntityRefTest {
   public void testUnregistered() throws Throwable {
     registry().refFor(AnotherEntity.class, "1");
   }
-
 }

--- a/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceSpec.scala
+++ b/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistenceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase
@@ -14,7 +14,6 @@ import com.lightbend.lagom.persistence.{ActorSystemSpec, PersistenceSpec}
 import com.typesafe.config.{Config, ConfigFactory}
 
 class CouchbasePersistenceSpec private (system: ActorSystem) extends ActorSystemSpec(system) with CouchbaseBucketSetup {
-
   def this(testName: String, config: Config) =
     this(
       ActorSystem(
@@ -37,5 +36,4 @@ class CouchbasePersistenceSpec private (system: ActorSystem) extends ActorSystem
     val cluster = Cluster(system)
     cluster.join(cluster.selfAddress)
   }
-
 }

--- a/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistentEntityActorSpec.scala
+++ b/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbasePersistentEntityActorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase

--- a/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseReadSideSpec.scala
+++ b/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/CouchbaseReadSideSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase
@@ -20,7 +20,6 @@ import play.api.inject.guice.GuiceInjectorBuilder
 import com.lightbend.lagom.javadsl.persistence.TestEntityReadSide
 
 object CouchbaseReadSideSpec {
-
   val defaultConfig: Config = ConfigFactory.parseString("akka.loglevel = INFO")
 }
 
@@ -28,7 +27,6 @@ class CouchbaseReadSideSpec
     extends CouchbasePersistenceSpec(CouchbaseReadSideSpec.defaultConfig)
     with AbstractReadSideSpec
     with CouchbaseBucketSetup {
-
   private lazy val injector = new GuiceInjectorBuilder().build()
 
   lazy val testSession = couchbaseSession.asJava

--- a/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/testkit/EmbeddedCouchbasePersistentActorSpec.scala
+++ b/lagom-persistence-couchbase/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/couchbase/testkit/EmbeddedCouchbasePersistentActorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.javadsl.persistence.couchbase.testkit

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbasePersistentEntityRegistry.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbasePersistentEntityRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.scaladsl.persistence.couchbase
@@ -15,7 +15,6 @@ import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntit
  */
 private[lagom] final class CouchbasePersistentEntityRegistry(system: ActorSystem)
     extends AbstractPersistentEntityRegistry(system) {
-
   private val log = Logging.getLogger(system, getClass)
 
   CouchbaseConfigValidator.validateBucket("couchbase-journal.write", system.settings.config, log)

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbaseReadSideHandler.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbaseReadSideHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.scaladsl.persistence.couchbase
@@ -20,7 +20,6 @@ import scala.concurrent.{ExecutionContext, Future}
  * Internal API
  */
 private[couchbase] object CouchbaseReadSideHandler {
-
   type Handler[Event] = (CouchbaseSession, EventStreamElement[_ <: Event]) => Future[Done]
 
   def emptyHandler[Event]: Handler[Event] = (_, _) => Future.successful(Done)
@@ -39,7 +38,6 @@ private[couchbase] final class CouchbaseReadSideHandler[Event <: AggregateEvent[
     dispatcher: String
 )(implicit ec: ExecutionContext)
     extends ReadSideHandler[Event] {
-
   import CouchbaseReadSideHandler.Handler
 
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -80,7 +78,6 @@ private[couchbase] final class CouchbaseReadSideHandler[Event <: AggregateEvent[
           )
 
         invoke(handler, elem)
-
       }
       .withAttributes(ActorAttributes.dispatcher(dispatcher))
 }

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbaseReadSideImpl.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/CouchbaseReadSideImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.scaladsl.persistence.couchbase
@@ -21,11 +21,11 @@ import scala.reflect.ClassTag
 /**
  * Internal API
  */
-private[lagom] final class CouchbaseReadSideImpl(system: ActorSystem,
-                                                 couchbaseSession: CouchbaseSession,
-                                                 offsetStore: CouchbaseOffsetStore)
-    extends CouchbaseReadSide {
-
+private[lagom] final class CouchbaseReadSideImpl(
+    system: ActorSystem,
+    couchbaseSession: CouchbaseSession,
+    offsetStore: CouchbaseOffsetStore
+) extends CouchbaseReadSide {
   private val dispatcher = system.settings.config.getString("lagom.persistence.read-side.use-dispatcher")
   implicit val ec: MessageDispatcher = system.dispatchers.lookup(dispatcher)
 
@@ -60,12 +60,14 @@ private[lagom] final class CouchbaseReadSideImpl(system: ActorSystem,
       }
 
       override def build(): ReadSideHandler[Event] =
-        new CouchbaseReadSideHandler[Event](couchbaseSession,
-                                            offsetStore,
-                                            handlers,
-                                            globalPrepare,
-                                            prepare,
-                                            readSideId,
-                                            dispatcher)
+        new CouchbaseReadSideHandler[Event](
+          couchbaseSession,
+          offsetStore,
+          handlers,
+          globalPrepare,
+          prepare,
+          readSideId,
+          dispatcher
+        )
     }
 }

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/ScaladslCouchbaseOffsetStore.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/couchbase/ScaladslCouchbaseOffsetStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.internal.scaladsl.persistence.couchbase
@@ -12,7 +12,8 @@ import com.lightbend.lagom.internal.persistence.couchbase.CouchbaseOffsetStore
 /**
  * Internal API
  */
-private[lagom] final class ScaladslCouchbaseOffsetStore(system: ActorSystem,
-                                                        couchbase: CouchbaseSession,
-                                                        config: ReadSideConfig)
-    extends CouchbaseOffsetStore(system, config, couchbase)
+private[lagom] final class ScaladslCouchbaseOffsetStore(
+    system: ActorSystem,
+    couchbase: CouchbaseSession,
+    config: ReadSideConfig
+) extends CouchbaseOffsetStore(system, config, couchbase)

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistenceComponents.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistenceComponents.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -38,19 +38,16 @@ trait CouchbasePersistenceComponents
  * Write-side persistence Couchbase components (for compile-time injection).
  */
 trait WriteSideCouchbasePersistenceComponents extends WriteSidePersistenceComponents {
-
   override lazy val persistentEntityRegistry: PersistentEntityRegistry =
     new CouchbasePersistentEntityRegistry(actorSystem)
 
   def serviceLocator: ServiceLocator
-
 }
 
 /**
  * Read-side persistence Couchbase components (for compile-time injection).
  */
 trait ReadSideCouchbasePersistenceComponents extends ReadSidePersistenceComponents {
-
   private val log = Logging(actorSystem, classOf[ReadSideCouchbasePersistenceComponents])
 
   CouchbaseConfigValidator.validateBucket("lagom.persistence.read-side.couchbase", configuration.underlying, log)

--- a/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSide.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSide.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -18,12 +18,10 @@ import akka.stream.alpakka.couchbase.scaladsl.CouchbaseSession
  * This should be used to build and register a read side processor.
  */
 object CouchbaseReadSide {
-
   /**
    * Builder for the handler.
    */
   trait ReadSideHandlerBuilder[Event <: AggregateEvent[Event]] {
-
     /**
      * Set a global prepare callback.
      *
@@ -62,11 +60,9 @@ object CouchbaseReadSide {
      */
     def build(): ReadSideHandler[Event]
   }
-
 }
 
 trait CouchbaseReadSide {
-
   /**
    * Create a builder for a Cassandra read side event handler.
    *

--- a/lagom-persistence-couchbase/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseClusteredPersistentEntitySpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseClusteredPersistentEntitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -36,7 +36,6 @@ class CouchbaseClusteredPersistentEntitySpecMultiJvmNode3 extends CouchbaseClust
 
 class CouchbaseClusteredPersistentEntitySpec
     extends AbstractClusteredPersistentEntitySpec(CouchbaseClusteredPersistentEntityConfig) {
-
   import com.lightbend.lagom.scaladsl.persistence.couchbase.CouchbaseClusteredPersistentEntityConfig._
 
   override protected def atStartup(): Unit = {

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistenceSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistenceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -16,7 +16,6 @@ import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.{Config, ConfigFactory}
 
 class CouchbasePersistenceSpec private (system: ActorSystem) extends ActorSystemSpec(system) with CouchbaseBucketSetup {
-
   def this(testName: String, config: Config, jsonSerializerRegistry: JsonSerializerRegistry) =
     this(
       ActorSystem(
@@ -44,5 +43,4 @@ class CouchbasePersistenceSpec private (system: ActorSystem) extends ActorSystem
     val cluster = Cluster(system)
     cluster.join(cluster.selfAddress)
   }
-
 }

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistentEntityActorSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbasePersistentEntityActorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSideSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/CouchbaseReadSideSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -19,7 +19,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 object CouchbaseReadSideSpec {
-
   val defaultConfig: Config = ConfigFactory.parseString("akka.loglevel = info")
 }
 
@@ -27,7 +26,6 @@ class CouchbaseReadSideSpec
     extends CouchbasePersistenceSpec(CouchbaseReadSideSpec.defaultConfig, TestEntitySerializerRegistry)
     with AbstractReadSideSpec
     with CouchbaseBucketSetup {
-
   override protected lazy val persistentEntityRegistry = new CouchbasePersistentEntityRegistry(system)
 
   private lazy val offsetStore = new ScaladslCouchbaseOffsetStore(system, couchbaseSession, ReadSideConfig())
@@ -44,5 +42,4 @@ class CouchbaseReadSideSpec
     persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
-
 }

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/PersistentEntityRefSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/PersistentEntityRefSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -44,7 +44,6 @@ class PersistentEntityRefSpec
     with TypeCheckedTripleEquals
     with CouchbaseBucketSetup // CouchbaseBucketSetup's only needed here for cleaning up the bucket before the test
     {
-
   override implicit val patienceConfig = PatienceConfig(5.seconds, 150.millis)
 
   private val config: Config = TestConfig
@@ -97,7 +96,6 @@ class PersistentEntityRefSpec
   }
 
   "The Couchbase persistence backend" should {
-
     "send commands to the registry" in {
       val ref1 = registry.refFor[TestEntity]("1")
       ref1
@@ -146,6 +144,5 @@ class PersistentEntityRefSpec
         registry.refFor[AnotherEntity]("whatever")
       }
     }
-
   }
 }

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/TestEntityReadSide.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/TestEntityReadSide.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase
@@ -17,7 +17,6 @@ import scala.concurrent.{ExecutionContext, Future}
 object TestEntityReadSide {
   class TestEntityReadSideProcessor(system: ActorSystem, readSide: CouchbaseReadSide)
       extends ReadSideProcessor[TestEntity.Evt] {
-
     @volatile private var prepared = false
 
     def buildHandler(): ReadSideHandler[TestEntity.Evt] = {
@@ -43,14 +42,13 @@ object TestEntityReadSide {
             Future {
               prepared = true
               Done
-          }
+            }
         )
         .setEventHandler[TestEntity.Appended](updateCount)
         .build()
     }
 
     def aggregateTags: Set[AggregateEventTag[TestEntity.Evt]] = TestEntity.Evt.aggregateEventShards.allTags
-
   }
 
   def getCount(session: CouchbaseSession, entityId: String)(implicit ec: ExecutionContext): Future[Long] =
@@ -58,11 +56,9 @@ object TestEntityReadSide {
       case Some(l) => l.content().getLong("count")
       case None => 0L
     }
-
 }
 
 class TestEntityReadSide(system: ActorSystem, couchbase: CouchbaseSession) {
-
   import system.dispatcher
 
   def getAppendCount(entityId: String): Future[Long] =

--- a/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/testkit/EmbeddedCouchbasePersistentActorSpec.scala
+++ b/lagom-persistence-couchbase/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/couchbase/testkit/EmbeddedCouchbasePersistentActorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package com.lightbend.lagom.scaladsl.persistence.couchbase.testkit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,5 +92,4 @@ object Dependencies {
     junit,
     junitInterface
   )
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,19 +1,20 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.1.0") // for maintenance of copyright file header
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0") // sources autoformat
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0") // for maintenance of copyright file header
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.2.1")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 
 // whitesource for tracking licenses and vulnerabilities in dependencies
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.14")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 
 // for releasing
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
 // docs
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.2")
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.23")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.3")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.26")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
 // patched version of sbt-dependency-graph

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0") // for maintenance of copyright file header
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.2.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 
 // whitesource for tracking licenses and vulnerabilities in dependencies


### PR DESCRIPTION
 - upgraded a few plugins (only tested the version bumps for scalafmt, javafmt and sbt-header)
 - configured formatting and header management for Multi JVM
 - edited header to `2018-2019`